### PR TITLE
CI and packaging modernizations and improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,14 @@ name: Publish
 on: push
 
 jobs:
-  build-n-push:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 
@@ -20,17 +20,19 @@ jobs:
       run: python -m build
 
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip_existing: true
         password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip_existing: true
         password: ${{ secrets.PYPI_TOKEN }}
+
     #- name: publish-to-conda
     #  if: startsWith(github.ref, 'refs/tags')
     #  uses: m0nhawk/conda-package-publish-action@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install pep517
-      run: >-
-        python -m pip install pep517 --user
+
+    - name: Install pypa/build
+      run: pip install build
     - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m pep517.build --source --binary --out-dir dist/ .
+      run: python -m build
+
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@v1.3.1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,4 @@ jobs:
           --user panodata \
           --repo grafana-client \
           --tag ${{ steps.version.outputs.VERSION }} \
-          --name ${{ steps.version.outputs.VERSION }} \
-          --description "$(cat $GITHUB_WORKSPACE/CHANGELOG.md)"
+          --name ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,22 +19,20 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          # Only needed for `pypy3`.
+          # Only needed for PyPy3.
           sudo apt install libxml2-dev libxslt-dev
           python -m pip install --upgrade pip
           python -m pip install .[test]
-        shell: bash
       - name: Run tests
         run: |
           coverage run --source grafana_client -m xmlrunner discover -o test-reports
           coverage xml
-        shell: bash
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,5 @@ jobs:
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v2
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
+        continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,12 @@ name: Test
 
 on:
   pull_request:
+    branches: [ main ]
     paths:
       - '.github/workflows/test.yml'
       - '**.py'
   push:
+    branches: [ main ]
     paths:
       - '.github/workflows/test.yml'
       - '**.py'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add `MANIFEST.in` to exclude specific files from `sdist` package
 * CI: Update from `pep517.build` to `build`
 * CI: Modernize package versions
+* CI: Don't fail run when upload to Codecov fails
 
 
 <a name="1.0.3"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # CHANGELOG
 
+## in progress
+* CI: Make release job grab the complete repository history. Thanks, Andrew!
+* CI: Fix path to `conda/setup.py`
+* Improve README: Add examples for creating a user and an organization.
+  Thanks, Anton!
+* Fork the repository to https://github.com/panodata/grafana-client.
+  Discussion: https://github.com/m0nhawk/grafana_api/issues/88.
+* Rename Python package from `grafana_api` to `grafana-client` and
+  update the repository location.
+* CI: Fix tests on PyPy by installing `libxml2-dev` and `libxslt-dev`
+* CI: Fix Codecov uploader by using GitHub Action recipe
+* CI: Remove CodeQL analysis
+* Adjust documentation to project fork
+* CI: Expand test matrix by Python 3.9 and 3.10
+* Add `CHANGELOG.md`, generated with `chglog`
+* CI: Remove automatic changelog generation with `chglog`
+* Refactoring: Rename module names and references
+* Format code with `black` and `isort`
+* Improve inline documentation
+
+
 <a name="1.0.3"></a>
 ## [1.0.3](https://github.com/panodata/grafana-client/compare/1.0.2...1.0.3) (2020-08-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Format code with `black` and `isort`
 * Improve inline documentation
 * Add `MANIFEST.in` to exclude specific files from `sdist` package
+* CI: Update from `pep517.build` to `build`
 
 
 <a name="1.0.3"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Refactoring: Rename module names and references
 * Format code with `black` and `isort`
 * Improve inline documentation
+* Add `MANIFEST.in` to exclude specific files from `sdist` package
 
 
 <a name="1.0.3"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Improve inline documentation
 * Add `MANIFEST.in` to exclude specific files from `sdist` package
 * CI: Update from `pep517.build` to `build`
+* CI: Modernize package versions
 
 
 <a name="1.0.3"></a>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+# `setuptools_scm` already includes all files tracked by Git.
+# This explicitly excludes specific committed files not needed in the sdist package.
+exclude .gitattributes .gitignore Makefile CODEOWNERS
+prune .github

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,7 +1,3 @@
 # grafana-client backlog
 
-- `python -m pep517.build --source --binary --out-dir dist/ .`
-  pep517.build is deprecated. Consider switching to https://pypi.org/project/build/
-- Format code with `black` and `isort``
 - Clarify *"To use admin API you need to use basic auth"*, see README.
-- Check contents of PyPI package vs. `MANIFEST.in`


### PR DESCRIPTION
- Retroactively update changelog for changes since version 1.0.3
- Add `MANIFEST.in` file to exclude specific files from sdist package
- Update from `pep517.build` to `build`
- Modernize package versions in GHA recipes