### PR TITLE
add health and datasource proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,4 @@ venv.bak/
 .mypy_cache/
 
 # visual code launch...
-.vscode/launch.json
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# visual code launch...
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This table outlines which parts of Grafana's HTTP API are covered by
 | Folder | + |
 | Folder Permissions | + |
 | Folder/Dashboard Search | +- |
+| Health | + |
 | Organisation | + |
 | Other | + |
 | Preferences | + |

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -5,6 +5,7 @@ from .elements import (
     Dashboard,
     Datasource,
     Folder,
+    Health,
     Notifications,
     Organization,
     Organizations,
@@ -40,6 +41,7 @@ class GrafanaApi:
         self.dashboard = Dashboard(self.client)
         self.datasource = Datasource(self.client)
         self.folder = Folder(self.client)
+        self.health = Health(self.client)
         self.organization = Organization(self.client)
         self.organizations = Organizations(self.client)
         self.search = Search(self.client)

--- a/grafana_client/elements/__init__.py
+++ b/grafana_client/elements/__init__.py
@@ -3,6 +3,7 @@ from .annotations import Annotations
 from .base import Base
 from .dashboard import Dashboard
 from .datasource import Datasource
+from .health import Health
 from .folder import Folder
 from .notifications import Notifications
 from .organization import Organization, Organizations

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -114,12 +114,12 @@ class Datasource(Base):
 
         :return: r (dict)
         """
-        get_datasource_path = "/datasources/proxy/{}" \
-		'/api/{}/{}?query={}'.format( datasource_id, version, query_type, expr)
+        get_datasource_path = "/datasources/proxy/{0}" \
+		    '/api/{1}/{2}?query={3}'.format( datasource_id, version, query_type, expr)
         if query_type == 'query_range':
-           get_datasource_path = get_datasource_path + '&start={}&end={}&step={}'.format(
-		start, end, step)
+            get_datasource_path = get_datasource_path + '&start={0}&end={1}&step={2}'.format(
+		        start, end, step)
         else:
-           get_datasource_path = get_datasource_path + '&time={}'.format(time)
-        r = self.api.GET(get_datasource_path)
+            get_datasource_path = get_datasource_path + '&time={}'.format(time)
+        r = self.client.GET(get_datasource_path)
         return r

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -95,3 +95,31 @@ class Datasource(Base):
         delete_datasource = "/datasources/name/%s" % datasource_name
         r = self.client.DELETE(delete_datasource)
         return r
+
+    def get_datasource_proxy_data(self, datasource_id
+        , query_type='query'
+        , version='v1'
+        , expr=None
+        , time=None
+        , start=None
+        , end=None
+        , step=None
+        ):
+        """
+
+        :param datasource_id:
+        :param version: api_version currently v1
+        :param query_type: query_range |query
+        :param expr: expr to query
+
+        :return: r (dict)
+        """
+        get_datasource_path = "/datasources/proxy/{}" \
+		'/api/{}/{}?query={}'.format( datasource_id, version, query_type, expr)
+        if query_type == 'query_range':
+           get_datasource_path = get_datasource_path + '&start={}&end={}&step={}'.format(
+		start, end, step)
+        else:
+           get_datasource_path = get_datasource_path + '&time={}'.format(time)
+        r = self.api.GET(get_datasource_path)
+        return r

--- a/grafana_client/elements/health.py
+++ b/grafana_client/elements/health.py
@@ -1,0 +1,16 @@
+from .base import Base
+
+
+class Health(Base):
+    def __init__(self, client):
+        super(Health, self).__init__(client)
+        self.client = client
+
+    def check(self):
+        """
+
+        :return:
+        """
+        path = "/health"
+        r = self.client.GET(path)
+        return r

--- a/test/elements/test_datasource.py
+++ b/test/elements/test_datasource.py
@@ -1,0 +1,143 @@
+import json
+import unittest
+
+import requests_mock
+
+from grafana_client import GrafanaApi
+from grafana_client.client import (
+    GrafanaBadInputError,
+    GrafanaClientError,
+    GrafanaServerError,
+    GrafanaUnauthorizedError,
+)
+
+
+class DatasourceTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+
+    @requests_mock.Mocker()
+    def test_find_datasource(self, m):
+        m.get(
+            "http://localhost/api/datasources/name/Prometheus",
+            json={
+                "id":1,
+                "uid":"h8KkCLt7z",
+                "orgId":1,
+                "name":"Prometheus",
+                "type":"prometheus",
+                "typeName":"Prometheus",
+                "typeLogoUrl":"public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+                "access":"proxy",
+                "url":"http://localhost:9090",
+                "password":"",
+                "user":"",
+                "database":"",
+                "basicAuth": False,
+                "isDefault": True,
+                "jsonData":{
+                    "httpMethod":"POST"
+                },
+                "readOnly": False
+            }
+        )
+
+        result = self.grafana.datasource.find_datasource('Prometheus')
+        self.assertEqual(result["type"], 'prometheus')
+
+    @requests_mock.Mocker()
+    def test_find_datasource_not_existing(self, m):
+        m.get(
+            "http://localhost/api/datasources/name/it_doesnot_exist",
+            json= {"message": "Data source not found"},
+            status_code=400
+        )
+
+        with self.assertRaises(GrafanaBadInputError):
+            result = self.grafana.datasource.find_datasource('it_doesnot_exist')
+
+
+    @requests_mock.Mocker()
+    def test_get_datasource_id_by_name(self, m):
+        m.get(
+            "http://localhost/api/datasources/id/Prometheus",
+            json={"id": 1}
+        )
+
+        result = self.grafana.datasource.get_datasource_id_by_name('Prometheus')
+        self.assertEqual(result["id"], 1)
+
+
+    @requests_mock.Mocker()
+    def test_list_datasources(self, m):
+        m.get(
+            "http://localhost/api/datasources",
+            json=[
+                {
+                    "id":1,
+                    "uid":"h8KkCLt7z",
+                    "orgId":1,
+                    "name":"Prometheus",
+                    "type":"prometheus",
+                    "typeName":"Prometheus",
+                    "typeLogoUrl":"public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+                    "access":"proxy",
+                    "url":"http://localhost:9090",
+                    "password":"",
+                    "user":"",
+                    "database":"",
+                    "basicAuth": False,
+                    "isDefault": True,
+                    "jsonData":{
+                        "httpMethod":"POST"
+                    },
+                    "readOnly": False
+                }
+            ],
+        )
+
+        result = self.grafana.datasource.list_datasources()
+        self.assertEqual(result[0]["type"], 'prometheus')
+        self.assertEqual(len(result), 1)
+
+    @requests_mock.Mocker()
+    def test_get_datasource_proxy_data(self, m):
+        # http://localhost:3000/api/datasources/proxy/1/api/v1/query_range?query=up%7binstance%3d%22localhost:9090%22%7d&start=1644164339&end=1644164639&step=60 
+        m.get(
+            "http://localhost/api/datasources/proxy/1/api/v1/query_range",
+            json={
+                "status": "success",
+                "data": {
+                    "resultType": "matrix",
+                    "result":[
+                        {
+                            "metric":{
+                                "__name__":"up",
+                                "instance":"localhost:9090",
+                                "job":"prometheus"
+                            },
+                            "values":[
+                                [1644164339,"1"],
+                                [1644164399,"1"],
+                                [1644164459,"1"],
+                                [1644164519,"1"],
+                                [1644164579,"1"],
+                                [1644164639,"1"]
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+        result = self.grafana.datasource.get_datasource_proxy_data(
+            1, # datasource_id
+            query_type='query_range',
+            expr="up{instance=\"localhost:9090\"}",
+            start=1644164339,
+            end=1644164639,
+            step=60,
+        )
+        self.assertEqual(result["status"], 'success')
+        self.assertEqual(result["data"]["result"][0]["metric"]["job"], 'prometheus')
+        self.assertEqual(len(result["data"]["result"][0]["values"]), 6)

--- a/test/elements/test_health.py
+++ b/test/elements/test_health.py
@@ -1,0 +1,33 @@
+import unittest
+
+import requests_mock
+
+from grafana_client import GrafanaApi
+from grafana_client.client import (
+    GrafanaBadInputError,
+    GrafanaClientError,
+    GrafanaServerError,
+    GrafanaUnauthorizedError,
+)
+
+
+class HealthTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+    @requests_mock.Mocker()
+    def test_search_dashboards(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json=[
+                {
+                    "commit": "6f8c1d9fe4",
+                    "database": "ok",
+                    "version": "7.5.11"
+                }
+            ],
+        )
+
+        result = self.grafana.health.check()
+        self.assertEqual(result[0]["database"], 'ok')
+        self.assertEqual(len(result), 1)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change or which issue is fixed (fixes #(issue)). -->

 *  Add interface to Grafana's "health" endpoint (/api/health)
 *  Add new method `get_datasource_proxy_data()` (/api/datasource/proxy...) on "datasource" element to be able to collect data info through Grafana.

## Notes
 * This is a port of https://github.com/m0nhawk/grafana_api/pull/81 to the new code base.

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
