### PR TITLE
Fix "folderId" propagation for "update_dashboard"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add handler for health API. Thanks, @peekjef72!
 * Add support for datasource proxying. Thanks, @peekjef72!
 * Fix compatibility between `actions/checkout@v2` and `setuptools_scm`
+* Fix `folderId` propagation for `update_dashboard`
 
 
 ## 2.0.2 (2022-02-03)

--- a/grafana_client/elements/dashboard.py
+++ b/grafana_client/elements/dashboard.py
@@ -22,6 +22,14 @@ class Dashboard(Base):
         :param dashboard:
         :return:
         """
+
+        # When the "folderId" is not available within the dashboard payload,
+        # populate it from the nested "meta" object, if given.
+        if "folderId" not in dashboard:
+            if "meta" in dashboard and "folderId" in dashboard["meta"]:
+                dashboard = dashboard.copy()
+                dashboard["folderId"] = dashboard["meta"]["folderId"]
+
         put_dashboard_path = "/dashboards/db"
         r = self.client.POST(put_dashboard_path, json=dashboard)
         return r

--- a/test/elements/test_dashboard.py
+++ b/test/elements/test_dashboard.py
@@ -35,6 +35,9 @@ class DashboardTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_update_dashboard(self, m):
+        """
+        Verify a general dashboard update.
+        """
         m.post(
             "http://localhost/api/dashboards/db",
             json={
@@ -64,6 +67,47 @@ class DashboardTestCase(unittest.TestCase):
 
         self.assertEqual(dashboard["uid"], "cIBgcSjkk")
         self.assertEqual(dashboard["status"], "success")
+
+    @requests_mock.Mocker()
+    def test_update_dashboard_roundtrip_folder_1(self, m):
+        """
+        Verify that a dashboard update will use the "folderId"
+        from the nested "meta" object.
+        This is important when roundtripping dashboard payloads.
+        """
+        m.post("http://localhost/api/dashboards/db", json={})
+        self.grafana.dashboard.update_dashboard(
+            {
+                "meta": {
+                    "folderId": 123,
+                },
+                "dashboard": {},
+            }
+        )
+
+        self.assertEqual(m.last_request.json()["folderId"], 123)
+
+    @requests_mock.Mocker()
+    def test_update_dashboard_roundtrip_folder_2(self, m):
+        """
+        Verify that a dashboard update will use the "folderId"
+        from the toplevel dashboard payload, even if it is present
+        within the nested "meta" object.
+        This is important when roundtripping dashboard payloads and
+        intentionally wanting to move the dashboard to a different folder.
+        """
+        m.post("http://localhost/api/dashboards/db", json={})
+        self.grafana.dashboard.update_dashboard(
+            {
+                "meta": {
+                    "folderId": 123,
+                },
+                "dashboard": {},
+                "folderId": 456,
+            }
+        )
+
+        self.assertEqual(m.last_request.json()["folderId"], 456)
 
     @requests_mock.Mocker()
     def test_get_home_dashboard(self, m):


### PR DESCRIPTION
Hi there,

coming from the original patch https://github.com/m0nhawk/grafana_api/pull/85, this fixes https://github.com/m0nhawk/grafana_api/issues/82. Users reported the original flaw through https://github.com/panodata/grafana-wtf/issues/5.

When the `folderId` is not available within the dashboard payload, populate it from the nested `meta` object, if given. On the other hand, if it *is* given within the dashboard payload, it should take precedence.

With kind regards,
Andreas.

/cc @pierluigilenoci, @JackNelson