### PR TITLE
Retrieve dashboard by name/title

### DIFF
--- a/grafana_client/elements/dashboard.py
+++ b/grafana_client/elements/dashboard.py
@@ -15,6 +15,16 @@ class Dashboard(Base):
         get_dashboard_path = "/dashboards/uid/%s" % dashboard_uid
         r = self.client.GET(get_dashboard_path)
         return r
+    
+    def get_dashboard_by_name(self, dashboard_name):
+        """
+
+        :param dashboard_name:
+        :return:
+        """
+        get_dashboard_path = "/dashboards/db/%s" % dashboard_name
+        r = self.api.GET(get_dashboard_path)
+        return r
 
     def update_dashboard(self, dashboard):
         """

--- a/grafana_client/elements/dashboard.py
+++ b/grafana_client/elements/dashboard.py
@@ -23,7 +23,7 @@ class Dashboard(Base):
         :return:
         """
         get_dashboard_path = "/dashboards/db/%s" % dashboard_name
-        r = self.api.GET(get_dashboard_path)
+        r = self.client.GET(get_dashboard_path)
         return r
 
     def update_dashboard(self, dashboard):

--- a/test/elements/test_dashboard.py
+++ b/test/elements/test_dashboard.py
@@ -36,7 +36,7 @@ class DashboardTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_dashboard_by_name(self, m):
         m.get(
-            "http://localhost/api/dashboards/name/Production%Overview",
+            "http://localhost/api/dashboards/db/Production Overview",
             json={
                 "dashboard": {
                     "id": 1,
@@ -55,7 +55,7 @@ class DashboardTestCase(unittest.TestCase):
             },
         )
         dashboard = self.grafana.dashboard.get_dashboard_by_name("Production Overview")
-        self.assertEqual(dashboard["dashboard"]["name"], "Production Overview")    
+        self.assertEqual(dashboard["dashboard"]["title"], "Production Overview")  
 
     @requests_mock.Mocker()
     def test_update_dashboard(self, m):

--- a/test/elements/test_dashboard.py
+++ b/test/elements/test_dashboard.py
@@ -32,6 +32,30 @@ class DashboardTestCase(unittest.TestCase):
         )
         dashboard = self.grafana.dashboard.get_dashboard("cIBgcSjkk")
         self.assertEqual(dashboard["dashboard"]["uid"], "cIBgcSjkk")
+        
+    @requests_mock.Mocker()
+    def test_get_dashboard_by_name(self, m):
+        m.get(
+            "http://localhost/api/dashboards/name/Production%Overview",
+            json={
+                "dashboard": {
+                    "id": 1,
+                    "uid": "cIBgcSjkk",
+                    "title": "Production Overview",
+                    "tags": ["templated"],
+                    "timezone": "browser",
+                    "schemaVersion": 16,
+                    "version": 0,
+                },
+                "meta": {
+                    "isStarred": "false",
+                    "url": "/d/cIBgcSjkk/production-overview",
+                    "slug": "production-overview",
+                },
+            },
+        )
+        dashboard = self.grafana.dashboard.get_dashboard_by_name("Production Overview")
+        self.assertEqual(dashboard["dashboard"]["name"], "Production Overview")    
 
     @requests_mock.Mocker()
     def test_update_dashboard(self, m):


### PR DESCRIPTION
## Description
Coming from https://github.com/m0nhawk/grafana_api/issues/91, there is the new function `get_dashboard_by_name` introduced so the dashboards can be found by name and not only id.

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
