### PR TITLE
fixing case on annotations query string parameter dashboardId

### DIFF
--- a/grafana_client/elements/annotations.py
+++ b/grafana_client/elements/annotations.py
@@ -46,7 +46,7 @@ class Annotations(Base):
             params.append("alertId=%s" % alert_id)
 
         if dashboard_id:
-            params.append("dashboardID=%s" % dashboard_id)
+            params.append("dashboardId=%s" % dashboard_id)
 
         if panel_id:
             params.append("panelId=%s" % panel_id)

--- a/test/elements/test_annotations.py
+++ b/test/elements/test_annotations.py
@@ -19,7 +19,7 @@ class AnnotationsTestCase(unittest.TestCase):
     def test_annotations(self, m):
         m.get(
             "http://localhost/api/annotations?from=1563183710618&to=1563185212275"
-            "&alertId=11&dashboardID=111&panelId=22&tags=tags-test&limit=1",
+            "&alertId=11&dashboardId=111&panelId=22&tags=tags-test&limit=1",
             json=[
                 {
                     "id": 80,


### PR DESCRIPTION
## Description
Fixes a subtle bug in the annotations API request.

In the Grafana API docs for [annotations](https://grafana.com/docs/grafana/latest/http_api/annotations/) the correct form of the dashboard id parameter is `dashboardId`.  In the Annotations class, this was incorrectly represented by the string `dashboardID` (note the upper/lower case of the final character).  This caused the dashboard id value to be ignored by the Grafana API, so, for instance, if you made a call to `get_annotation` that looked like this:
```
get_annotation(dashboard_id=10, panel_id=8)
```
you'd get annotations from ALL panel 8s across ALL dashboards on the host.  Correcting the parameter name fixes this behavior so it only returns annotations from the panel 8 that appears on dashboard 10.

## Checklist

- [ x] The patch has appropriate test coverage
- [ x] The patch follows the style guidelines of this project
- [ x] The patch has appropriate comments, particularly in hard-to-understand areas
- [ x] The documentation was updated corresponding to the patch
- [ x] I have performed a self-review of this patch
