### PR TITLE
Support data source health check endpoint introduced with Grafana 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Improve data source API by adding the `_by_uid` variants.
 * Improve data source API by adding universal `datasource.get()` method.
 * Improve data source API by adding a data source health-check probe.
+* Support data source health check endpoint introduced with Grafana 9.
+  Thanks, @jangaraj!
 
 
 ## 2.3.0 (2022-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Improve data source API by adding a data source health-check probe.
 * Support data source health check endpoint introduced with Grafana 9.
   Thanks, @jangaraj!
+* Add gracefulness when using the new data source health check endpoint.
+  Apparently, this is not implemented thoroughly for all data source types yet.
 
 
 ## 2.3.0 (2022-05-26)

--- a/examples/datasource-health.py
+++ b/examples/datasource-health.py
@@ -73,13 +73,16 @@ def health_inquiry(grafana: GrafanaApi, datasource: DatasourceModel, grafana_ver
     datasource = grafana.datasource.get(datasource_id=datasource_id)
 
     # Check data source health.
+    health = None
     if True or grafana_version and grafana_version >= VERSION_9:
         try:
             health = grafana.datasource.health(datasource_uid=datasource_uid)
         except GrafanaClientError as ex:
-            logger.error(f"Data source health check for uid={datasource_uid} failed: {ex}. Response: {ex.response}")
-            raise
-    else:
+            logger.warning(f"Native data source health check for uid={datasource_uid} failed: {ex}. Response: {ex.response}")
+            if ex.status_code != 404:
+                raise
+
+    if health is None:
         health = grafana.datasource.health_check(datasource=datasource)
 
     # Delete data source again.

--- a/examples/datasource-health.rst
+++ b/examples/datasource-health.rst
@@ -43,6 +43,7 @@ Start Grafana::
     export GRAFANA_VERSION=7.5.16
     export GRAFANA_VERSION=8.5.6
     export GRAFANA_VERSION=9.0.0
+    export GRAFANA_VERSION=main
 
     docker run --rm -it \
         --publish=3000:3000 \

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -18,6 +18,19 @@ class Datasource(Base):
         super(Datasource, self).__init__(client)
         self.client = client
 
+    def health(self, datasource_uid: str):
+        """
+        Makes a call to the health endpoint of a data source identified by the
+        given ``uid``.
+
+        Available in Grafana 9+.
+
+        https://grafana.com/docs/grafana/latest/developers/http_api/data_source/#check-data-source-health
+        """
+        path = f"/datasources/uid/{datasource_uid}/health"
+        r = self.client.GET(path)
+        return r
+
     def find_datasource(self, datasource_name):
         """
 


### PR DESCRIPTION
@jangaraj mentioned at https://github.com/panodata/grafana-client/issues/20#issuecomment-1160385363, that Grafana 9 features a dedicated data source health check endpoint [^1]. This patch implements the corresponding client support.

[^1]: https://grafana.com/docs/grafana/latest/developers/http_api/data_source/#check-data-source-health
