### PR TITLE
Working on 2.4.0 - part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   Apparently, this is not implemented thoroughly for all data source types yet.
 * Add new factory methods `GrafanaApi.{from_url(),from_env()}`.
 * Add `GrafanaApi.connect()` and `GrafanaApi.version()`.
+* Data source health check subsystem refactoring, many software tests.
 
 
 ## 2.3.0 (2022-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Data source health check subsystem refactoring, many software tests.
 * Improve example programs `datasource-health-*`
 * Add example program `datasource-query.py`
+* Add example program `grafanalib-upload-dashboard.py`
 
 
 ## 2.3.0 (2022-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add `GrafanaApi.connect()` and `GrafanaApi.version()`.
 * Data source health check subsystem refactoring, many software tests.
 * Improve example programs `datasource-health-*`
+* Add example program `datasource-query.py`
 
 
 ## 2.3.0 (2022-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add new factory methods `GrafanaApi.{from_url(),from_env()}`.
 * Add `GrafanaApi.connect()` and `GrafanaApi.version()`.
 * Data source health check subsystem refactoring, many software tests.
+* Improve example programs `datasource-health-*`
 
 
 ## 2.3.0 (2022-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add gracefulness when using the new data source health check endpoint.
   Apparently, this is not implemented thoroughly for all data source types yet.
 * Add new factory methods `GrafanaApi.{from_url(),from_env()}`.
+* Add `GrafanaApi.connect()` and `GrafanaApi.version()`.
 
 
 ## 2.3.0 (2022-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   Thanks, @jangaraj!
 * Add gracefulness when using the new data source health check endpoint.
   Apparently, this is not implemented thoroughly for all data source types yet.
+* Add new factory methods `GrafanaApi.{from_url(),from_env()}`.
 
 
 ## 2.3.0 (2022-05-26)

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,8 @@ format:
 .PHONY: test
 test:
 	python -m unittest -vvv
+
+.PHONY: test-coverage
+test-coverage:
+	coverage run -m unittest -vvv
+	coverage report

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Connect to your Grafana API endpoint using the `GrafanaApi` class.
 ```python
 from grafana_client import GrafanaApi
 
-grafana = GrafanaApi(auth='eyJrIjoiWHg...dGJpZCI6MX0=', host='grafana.example.org')
+grafana = GrafanaApi.from_url("https://grafana.example.org/grafana")
 
 # Create user
 user = grafana.admin.create_user(

--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ user = grafana.admin.create_user(
 user = grafana.admin.change_user_password(2, "newpassword")
 
 # Search dashboards based on tag
-grafana.search.search_dashboards(tag='applications')
+grafana.search.search_dashboards(tag="applications")
 
 # Find a user by email
-user = grafana.users.find_user('test@example.org')
+user = grafana.users.find_user("test@example.org")
 
 # Add user to team 2
 grafana.teams.add_team_member(2, user["id"])
 
 # Create or update a dashboard
-grafana.dashboard.update_dashboard(dashboard={'dashboard': {...}, 'folderId': 0, 'overwrite': True})
+grafana.dashboard.update_dashboard(dashboard={"dashboard": {...}, "folderId": 0, "overwrite": True})
 
 # Delete a dashboard by UID
-grafana.dashboard.delete_dashboard(dashboard_uid='abcdefgh')
+grafana.dashboard.delete_dashboard(dashboard_uid="foobar")
 
 # Create organization
 grafana.organization.create_organization({"name": "new_organization"})
@@ -65,31 +65,49 @@ grafana.organization.create_organization({"name": "new_organization"})
 There are two ways to authenticate to the Grafana API. Either use an API token,
 or HTTP basic auth.
 
-To use the admin API, you need to use HTTP basic auth, as stated at the
-[Grafana Admin API documentation].
+To use the admin API, you need to use HTTP basic authentication, as stated at
+the [Grafana Admin API documentation].
 
 ```python
 from grafana_client import GrafanaApi
 
-# Use HTTP basic authentication
-grafana = GrafanaApi(
-    auth=("username", "password"),
-    host='grafana.example.org'
+# Use Grafana API token.
+grafana = GrafanaApi.from_url(
+    url="https://grafana.example.org/grafana",
+    auth="eyJrIjoiWHg...dGJpZCI6MX0=",
 )
 
-# Use Grafana API token
-grafana = GrafanaApi(
-    auth='eyJrIjoiWHg...dGJpZCI6MX0=',
-    host='grafana.example.org'
+# Use HTTP basic authentication.
+grafana = GrafanaApi.from_url(
+    url="https://username:password@grafana.example.org/grafana",
 )
+
+# Optionally turn off TLS certificate verification.
+grafana = GrafanaApi.from_url(
+    url="https://username:password@grafana.example.org/grafana?verify=false",
+)
+
+# Use `GRAFANA_URL` and `GRAFANA_TOKEN` environment variables.
+grafana = GrafanaApi.from_env()
+```
+
+## Proxy
+
+The underlying `requests` library honors the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables. Setting them before invoking an application using
+`grafana-client` has been confirmed to work. For example:
+```
+export HTTP_PROXY=10.10.1.10:3128
+export HTTPS_PROXY=10.10.1.11:1080
 ```
 
 
-## Status
+## Details
 
-This table outlines which parts of Grafana's HTTP API are covered by
-`grafana-client`, see also [Grafana HTTP API reference].
+This section of the documentation outlines which parts of the Grafana HTTP API
+are supported, and to which degree. See also [Grafana HTTP API reference].
 
+### Overview
 
 | API | Status |
 |---|---|
@@ -114,6 +132,41 @@ This table outlines which parts of Grafana's HTTP API are covered by
 | User | + |
 
 
+### Data source health check
+
+#### Introduction
+
+For checking whether a Grafana data source is healthy, Grafana 9 has a
+server-side data source health check API. For earlier versions, a client-side
+implementation is provided.
+
+This implementation works in the same manner as the "Save & test" button works,
+when creating a data source in the user interface.
+
+The feature can be explored through corresponding client programs in the
+`examples/` folder of this repository.
+
+#### Compatibility
+
+The minimum supported version is Grafana 7.x, it does not work on older
+versions of Grafana. Prometheus only works on Grafana 8.x and newer.
+
+#### Data source coverage
+
+Support for data source health checks on those Grafana data sources is
+implemented as of June 2022.
+
+- CrateDB
+- Elasticsearch
+- InfluxDB
+- PostgreSQL
+- Prometheus
+- Testdata
+
+We are humbly asking the community to contribute adapters for other data
+sources.
+
+
 ## Software tests
 
 ```shell
@@ -128,8 +181,10 @@ python -m unittest -vvv
 A list of applications based on `grafana-client`.
 
 - [grafana-import-tool](https://github.com/peekjef72/grafana-import-tool)
+- [grafana-ldap-sync-script](https://github.com/NovatecConsulting/grafana-ldap-sync-script)
 - [grafana-snapshots-tool](https://github.com/peekjef72/grafana-snapshots-tool)
 - [grafana-wtf](https://github.com/panodata/grafana-wtf)
+- [nixops-grafana](https://github.com/tewfik-ghariani/nixops-grafana)
 
 
 ## History

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,3 +1,26 @@
 # grafana-client backlog
 
-- Clarify *"To use admin API you need to use basic auth"*, see README.
+## Collected
+- [o] Clarify *"To use admin API you need to use basic auth"* in README
+- [o] Use appropriate user agent
+- [o] Provide example program with grafanalib
+- [o] Announcement on https://community.grafana.com/
+- [o] Documentation
+- [o] Tests
+- [o] Real data queries, see https://github.com/panodata/grafana-client/pull/5 ff.
+- [o] Provide example program for querying data sources
+- [o] Protect against submitting JSON into API methods
+- [o] Fix typo: `runnner`
+- [o] Make example program `datasource-query.py` fully work
+
+## Community contributions
+- [o] Fix "teams" bug
+  - https://github.com/panodata/grafana-client/issues/12
+  - https://github.com/changdingfang/grafana_api/commit/e762671
+- [o] Alerts API
+  - https://github.com/stephenlclarke/grafana_api/commit/606b58658e
+- [o] Dashboard versions
+  - https://github.com/DrMxxxxx/grafana_api/commit/fdf47a651be4
+- [o] Query range and series
+  - https://github.com/RalfHerzog/grafana_api/commit/57e1086a7
+  - https://github.com/RalfHerzog/grafana_api/commit/68d505e

--- a/examples/datasource-health-check.py
+++ b/examples/datasource-health-check.py
@@ -1,0 +1,54 @@
+"""
+Example program for checking whether a data source is healthy.
+
+Documentation: https://github.com/panodata/grafana-client/blob/main/examples/datasource-health-check.rst
+"""
+import json
+import logging
+import sys
+from distutils.version import LooseVersion
+from optparse import OptionParser
+
+import requests
+
+from grafana_client import GrafanaApi
+from grafana_client.util import setup_logging
+
+logger = logging.getLogger(__name__)
+
+VERSION_7 = LooseVersion("7")
+
+
+def run(grafana: GrafanaApi):
+    parser = OptionParser()
+    parser.add_option("--uid", dest="uid", help="Data source UID")
+    (options, args) = parser.parse_args()
+    if not options.uid:
+        parser.error("Option --uid required")
+
+    # Invoke the health check.
+    health_info = grafana.datasource.health_inquiry(datasource_uid=options.uid)
+
+    # Display the outcome and terminate program based on success state.
+    print(json.dumps(health_info.asdict_compact(), indent=2))
+    if not health_info.success:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+
+    setup_logging(level=logging.DEBUG)
+
+    # Connect to Grafana instance and run health check.
+    grafana_client = GrafanaApi.from_env()
+
+    try:
+        grafana_client.connect()
+    except requests.exceptions.ConnectionError as ex:
+        raise SystemExit(1)
+
+    grafana_version = LooseVersion(grafana_client.version)
+    if grafana_version < VERSION_7:
+        raise NotImplementedError(f"Data source health check subsystem not ready for Grafana version {grafana_version}")
+
+    run(grafana_client)

--- a/examples/datasource-health-check.rst
+++ b/examples/datasource-health-check.rst
@@ -1,0 +1,72 @@
+################################
+Grafana data source health check
+################################
+
+
+*****
+About
+*****
+
+``datasource-health-check.py`` is an example program which can be used to
+explore the data source health check feature on a remote Grafana instance.
+
+You will have to know the UID of the data source item in order to address
+it through the Grafana API.
+
+
+*****
+Usage
+*****
+
+Synopsis
+========
+
+Inquire the health status of an InfluxDB 1.7 data source on
+``play.grafana.org``::
+
+    export GRAFANA_URL=https://play.grafana.org/
+
+    python examples/datasource-health-check.py --uid=000000002
+
+    {
+      "uid": "000000002",
+      "type": "influxdb",
+      "success": true,
+      "status": "OK",
+      "message": "Success",
+      "duration": 0.1559
+    }
+
+More examples
+=============
+Inquire the health status of some other data sources on
+``play.grafana.org``::
+
+    export GRAFANA_URL=https://play.grafana.org/
+
+    # Graphite
+    # FIXME: Not implemented yet.
+    python examples/datasource-health-check.py --uid=000000001
+
+    # InfluxDB 1 / InfluxQL
+    python examples/datasource-health-check.py --uid=000000002
+
+    # Not found
+    python examples/datasource-health-check.py --uid=000000003
+
+    # Prometheus
+    python examples/datasource-health-check.py --uid=000000008
+    python examples/datasource-health-check.py --uid=NfggWZLGz
+
+    # Testdata
+    python examples/datasource-health-check.py --uid=000000051
+
+On both of those data source items, the new native server-side health check
+implementation of Grafana 9+ will be used::
+
+    # Cloudwatch
+    python examples/datasource-health-check.py --uid=000000098
+
+    # TwinMaker
+    python examples/datasource-health-check.py --uid=qenjJQtnk
+

--- a/examples/datasource-health-probe.rst
+++ b/examples/datasource-health-probe.rst
@@ -1,5 +1,5 @@
 ################################
-Grafana data source health check
+Grafana data source health probe
 ################################
 
 
@@ -7,31 +7,15 @@ Grafana data source health check
 About
 *****
 
-``datasource-health.py`` is a demo program for checking whether a Grafana data
-source is healthy, in the same manner like the "Save & test" button works, when
-creating a data source in the user interface.
+``datasource-health-probe.py`` is an example program which can be used to
+explore the data source health check feature on your local workstation, with
+both Grafana and database service instances started using Docker.
 
-Grafana compatibility
-=====================
+Data source items are created on demand, so this program needs corresponding
+permissions on the Grafana API to create and delete data source items.
 
-The minimum supported version is Grafana 7.x, it does not work on older
-versions of Grafana. Prometheus only works on Grafana 8.x and newer.
-
-
-Data source coverage
-====================
-
-Support for those Grafana data sources is implemented as of June, 2022.
-
-- CrateDB
-- Elasticsearch
-- InfluxDB
-- PostgreSQL
-- Prometheus
-- Testdata
-
-We are humbly asking the community to contribute adapters for other data
-sources.
+The created data source items will be called ``probe-{type}``. For example,
+``probe-prometheus``. After probing them, they will be deleted again.
 
 
 *****
@@ -42,7 +26,7 @@ Start Grafana::
 
     export GRAFANA_VERSION=7.5.16
     export GRAFANA_VERSION=8.5.6
-    export GRAFANA_VERSION=9.0.0
+    export GRAFANA_VERSION=9.0.1
     export GRAFANA_VERSION=main
 
     docker run --rm -it \
@@ -93,7 +77,7 @@ CrateDB
 ::
 
     docker run --rm -it --publish=4200:4200 --publish=5432:5432 crate:4.8.1
-    python examples/datasource-health.py --type=cratedb --url=host.docker.internal:5432
+    python examples/datasource-health-probe.py --type=cratedb --url=host.docker.internal:5432
 
 
 Elasticsearch
@@ -108,7 +92,7 @@ Elasticsearch
     {apt,brew} install httpie
     http POST "http://localhost:9200/testdrive/_doc/1?pretty" "\@timestamp=2022-06-20T16:04:22.396Z" "sensor=foobar-1" "value=42.42"
 
-    python examples/datasource-health.py --type=elasticsearch --url=http://host.docker.internal:9200
+    python examples/datasource-health-probe.py --type=elasticsearch --url=http://host.docker.internal:9200
 
 
 InfluxDB 1.x
@@ -117,7 +101,7 @@ InfluxDB 1.x
 
     docker run --rm -it --publish=8086:8086 influxdb:1.8
     docker run --rm -it --network=host influxdb:1.8 influx -host host.docker.internal
-    python examples/datasource-health.py --type=influxdb --url=http://host.docker.internal:8086
+    python examples/datasource-health-probe.py --type=influxdb --url=http://host.docker.internal:8086
 
 
 InfluxDB 2.x
@@ -133,7 +117,7 @@ InfluxDB 2.x
         --env=DOCKER_INFLUXDB_INIT_BUCKET=default \
         --env=DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=admintoken \
         influxdb:2.2
-    python examples/datasource-health.py --type=influxdb+flux --url=http://host.docker.internal:8086
+    python examples/datasource-health-probe.py --type=influxdb+flux --url=http://host.docker.internal:8086
 
     docker run --rm -it --network=host influxdb:2.2 influx org list --token=admintoken
     docker run --rm -it --network=host influxdb:2.2 influx bucket list --org=example --token=admintoken
@@ -147,7 +131,7 @@ PostgreSQL
 ::
 
     docker run --rm -it --publish=5432:5432 --env "POSTGRES_HOST_AUTH_METHOD=trust" postgres:14.3
-    python examples/datasource-health.py --type=postgres --url=host.docker.internal:5432
+    python examples/datasource-health-probe.py --type=postgres --url=host.docker.internal:5432
 
 
 Prometheus
@@ -155,11 +139,12 @@ Prometheus
 ::
 
     docker run --rm -it --publish=9090:9090 prom/prometheus
-    python examples/datasource-health.py --type=prometheus --url=http://host.docker.internal:9090
+    python examples/datasource-health-probe.py --type=prometheus --url=http://host.docker.internal:9090
 
 
-Test data source
-================
+Testdata
+========
 ::
 
-    python examples/datasource-health.py --type=testdata
+    python examples/datasource-health-probe.py --type=testdata
+

--- a/examples/datasource-query.py
+++ b/examples/datasource-query.py
@@ -1,0 +1,69 @@
+"""
+About
+=====
+
+Example program for submitting a query to a data source.
+
+While the ``--query`` option is obligatory, the ``--store`` option is not.
+It will be used to designate the ``database`` name, with e.g. InfluxDB,
+or the ``metric`` name, with e.g. Prometheus.
+
+Synopsis
+========
+::
+
+    # Query the InfluxDB 1.x data source on `play.grafana.org`.
+    python examples/datasource-query.py --uid=000000002 --query="SHOW RETENTION POLICIES on _internal"
+    python examples/datasource-query.py --uid=000000002 --store=site --query="SHOW FIELD KEYS"
+
+    # Query the Prometheus data source on `play.grafana.org`.
+    # FIXME: Does not work yet.
+    python examples/datasource-query.py --uid=000000008 --store=node_boot_time --query='time() - node_boot_time_seconds{job="node", instance=~"demo.do.prometheus.io:.*"}'
+
+"""
+import json
+import logging
+from optparse import OptionParser
+
+import requests
+
+from grafana_client import GrafanaApi
+from grafana_client.model import DatasourceIdentifier
+from grafana_client.util import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(grafana: GrafanaApi):
+    parser = OptionParser()
+    parser.add_option("--uid", dest="uid", help="Data source UID")
+    parser.add_option("--store", dest="store", help="Database or metric to be addressed")
+    parser.add_option("--query", dest="query", help="Query expression")
+    (options, args) = parser.parse_args()
+    if not options.uid:
+        parser.error("Option --uid required")
+    if not options.query:
+        parser.error("Option --query required")
+
+    # Query the data source by UID.
+    response = grafana.datasource.query(
+        DatasourceIdentifier(uid=options.uid), expression=options.query, store=options.store
+    )
+
+    # Display the outcome in JSON format.
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == "__main__":
+
+    setup_logging(level=logging.DEBUG)
+
+    # Connect to Grafana instance and run health check.
+    grafana_client = GrafanaApi.from_url("https://play.grafana.org/")
+
+    try:
+        grafana_client.connect()
+    except requests.exceptions.ConnectionError as ex:
+        raise SystemExit(1)
+
+    run(grafana_client)

--- a/examples/grafanalib-upload-dashboard.py
+++ b/examples/grafanalib-upload-dashboard.py
@@ -1,0 +1,108 @@
+"""
+About
+=====
+
+Example program demonstrating how to work with both `grafana-client`_ and
+`grafanalib`_. It reflects the example program `example.upload-dashboard.py`_
+from `grafanalib`_ and will create and upload a dashboard.
+
+Setup
+=====
+::
+
+    pip install grafana-client grafanalib
+
+Synopsis
+========
+::
+
+    # Invoke example program.
+    # By default, it will assume a Grafana instance accessible
+    # via `http://admin:admin@localhost:3000`.
+    python examples/grafanalib-upload-dashboard.py
+
+    # Optionally target a remote Grafana instance, with authentication token.
+    export GRAFANA_URL=https://grafana.example.org/
+    export GRAFANA_TOKEN=eyJrIjoiWHg...dGJpZCI6MX0=
+
+.. _example.upload-dashboard.py: https://github.com/weaveworks/grafanalib/blob/main/grafanalib/tests/examples/example.upload-dashboard.py
+.. _grafana-client: https://github.com/panodata/grafana-client
+.. _grafanalib: https://github.com/weaveworks/grafanalib
+"""
+import json
+import logging
+from typing import Dict
+
+from grafanalib._gen import DashboardEncoder
+from grafanalib.core import Dashboard
+
+from grafana_client import GrafanaApi
+from grafana_client.util import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def mkdashboard(uid: str, title: str = None, message: str = None, overwrite: bool = False) -> Dict:
+    """
+    Create a dashboard create/update payload using grafanalib, suitable for
+    submitting to the Grafana HTTP API.
+
+    Note: This is solely for demonstration purposes, a real-world
+    implementation would stuff more details into the dashboard beforehand.
+    """
+    dashboard = Dashboard(uid=uid, title=title)
+    data = {
+        "dashboard": encode_dashboard(dashboard),
+        "overwrite": overwrite,
+        "message": message,
+    }
+    return data
+
+
+def encode_dashboard(entity) -> Dict:
+    """
+    Encode grafanalib `Dashboard` entity to dictionary.
+
+    TODO: Optimize without going through JSON marshalling.
+    """
+    return json.loads(json.dumps(entity, sort_keys=True, cls=DashboardEncoder))
+
+
+def run(grafana: GrafanaApi):
+    """
+    The main body of the example program.
+
+    - Create a Grafana dashboard create/update payload.
+    - Submit to Grafana HTTP API.
+    - Display response.
+    """
+
+    # Create dashboard payload.
+    dashboard_payload = mkdashboard(
+        uid="abifsd",
+        title="My awesome dashboard",
+        message="Updated by grafanalib",
+        overwrite=True,
+    )
+
+    # Create or update dashboard at Grafana HTTP API.
+    response = grafana.dashboard.update_dashboard(dashboard_payload)
+
+    # Display the outcome in JSON format.
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == "__main__":
+    """
+    Boilerplate bootloader. Create a `GrafanaApi` instance and run example.
+    """
+
+    # Setup logging.
+    setup_logging(level=logging.DEBUG)
+
+    # Create a `GrafanaApi` instance, optionally configured with environment
+    # variables `GRAFANA_URL` and `GRAFANA_TOKEN`.
+    grafana_client = GrafanaApi.from_env()
+
+    # Invoke example conversation.
+    run(grafana_client)

--- a/grafana_client/__init__.py
+++ b/grafana_client/__init__.py
@@ -1,1 +1,4 @@
+import warnings
+
+warnings.filterwarnings("ignore", category=Warning, message="distutils Version classes are deprecated")
 from .api import GrafanaApi

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -1,3 +1,8 @@
+import os
+import warnings
+from typing import Tuple, Union
+from urllib.parse import parse_qs, urlparse
+from urllib3.exceptions import InsecureRequestWarning
 from .client import GrafanaClient
 from .elements import (
     Admin,
@@ -37,6 +42,7 @@ class GrafanaApi:
             verify=verify,
             timeout=timeout,
         )
+        self.url = None
         self.admin = Admin(self.client)
         self.dashboard = Dashboard(self.client)
         self.datasource = Datasource(self.client)
@@ -51,3 +57,49 @@ class GrafanaApi:
         self.annotations = Annotations(self.client)
         self.snapshots = Snapshots(self.client)
         self.notifications = Notifications(self.client)
+    @classmethod
+    def from_url(cls, url: str = None, credential: Union[str, Tuple[str, str]] = None):
+        """
+        Factory method to create a `GrafanaApi` instance from a URL.
+
+        Accepts an optional credential, which is either an authentication
+        token, or a tuple of (username, password).
+        """
+
+        # Sanity checks and defaults.
+        if url is None:
+            url = "http://admin:admin@localhost:3000"
+
+        if credential is not None and not isinstance(credential, (str, Tuple)):
+            raise TypeError(f"Argument 'credential' has wrong type: {type(credential)}")
+
+        original_url = url
+        url = urlparse(url)
+
+        # Use username and password from URL.
+        if credential is None and url.username:
+            credential = (url.username, url.password)
+
+        # Optionally turn off SSL verification.
+        verify = as_bool(parse_qs(url.query).get("verify", [True])[0])
+        if verify is False:
+            warnings.filterwarnings("ignore", category=InsecureRequestWarning)
+
+        grafana = cls(
+            credential,
+            protocol=url.scheme,
+            host=url.hostname,
+            port=url.port,
+            url_path_prefix=url.path.lstrip("/"),
+            verify=verify,
+        )
+        grafana.url = original_url
+
+        return grafana
+
+    @classmethod
+    def from_env(cls):
+        """
+        Factory method to create a `GrafanaApi` instance from environment variables.
+        """
+        return cls.from_url(url=os.environ.get("GRAFANA_URL"), credential=os.environ.get("GRAFANA_TOKEN"))

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -76,7 +76,7 @@ class GrafanaApi:
         return grafana_info
 
     @property
-    @memoized
+    @memoized(maxsize=1)
     def version(self):
         grafana_info = self.health.check()
         version = grafana_info["version"]

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -53,7 +53,7 @@ class GrafanaApi:
         self.url = None
         self.admin = Admin(self.client)
         self.dashboard = Dashboard(self.client)
-        self.datasource = Datasource(self.client)
+        self.datasource = Datasource(self.client, self)
         self.folder = Folder(self.client)
         self.health = Health(self.client)
         self.organization = Organization(self.client)

--- a/grafana_client/model.py
+++ b/grafana_client/model.py
@@ -1,9 +1,26 @@
 import dataclasses
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
+
+
+@dataclasses.dataclass
+class DatasourceIdentifier:
+    """
+    A Grafana data source can be identified by either a numerical id, an
+    alphanumerical uid, or a name.
+    """
+
+    id: Optional[str] = None
+    uid: Optional[str] = None
+    name: Optional[str] = None
 
 
 @dataclasses.dataclass
 class DatasourceModel:
+    """
+    Represent the minimum required fields to create a JSON payload suitable for
+    submitting to the Grafana HTTP API.
+    """
+
     name: str
     type: str
     url: str
@@ -19,16 +36,34 @@ class DatasourceModel:
 
 
 @dataclasses.dataclass
-class DatasourceHealth:
+class DatasourceHealthResponse:
+    """
+    Represent a response for a Grafana data source health check.
+
+    It is a mixture of the fields of the native, server-side health check
+    introduced with Grafana 9+, and the client-side implementation by
+    `grafana-client`.
+
+    - Grafana 9+ uses the fields `status` and `message`, where `status` can be
+      one of `OK`, or `ERROR`.
+    - `grafana-client` employs a more verbose response, including metadata
+      about the requested data source item (`uid`, `type`), a boolean `success`
+      flag, as well as the duration in seconds the request needed and the full
+      response object.
+    """
+
+    uid: str
+    type: Union[str, None]
     success: bool
+    status: str
     message: str
-    duration: float
-    response: Any
+    duration: Optional[float] = None
+    response: Optional[Any] = None
 
     def asdict(self):
         return dataclasses.asdict(self)
 
-    def for_response(self):
+    def asdict_compact(self):
         data = self.asdict()
         del data["response"]
         return data

--- a/grafana_client/util.py
+++ b/grafana_client/util.py
@@ -1,48 +1,10 @@
 import logging
 import sys
-import warnings
-from urllib.parse import parse_qs, urlparse
-
-from urllib3.exceptions import InsecureRequestWarning
 
 
 def setup_logging(level=logging.INFO):
-    log_format = "%(asctime)-15s [%(name)-35s] %(levelname)-7s: %(message)s"
+    log_format = "%(asctime)-15s [%(name)-35s] %(levelname)-8s: %(message)s"
     logging.basicConfig(format=log_format, stream=sys.stderr, level=level)
-
-
-def grafana_client_factory(grafana_url, grafana_token=None):
-    """
-    From `grafana-wtf`.
-    """
-    url = urlparse(grafana_url)
-
-    # Grafana API Key auth
-    if grafana_token:
-        auth = grafana_token
-
-    # HTTP basic auth
-    else:
-        username = url.username or "admin"
-        password = url.password or "admin"
-        auth = (username, password)
-
-    verify = as_bool(parse_qs(url.query).get("verify", [True])[0])
-    if verify is False:
-        warnings.filterwarnings("ignore", category=InsecureRequestWarning)
-
-    from grafana_client import GrafanaApi
-
-    grafana = GrafanaApi(
-        auth,
-        protocol=url.scheme,
-        host=url.hostname,
-        port=url.port,
-        url_path_prefix=url.path.lstrip("/"),
-        verify=verify,
-    )
-
-    return grafana
 
 
 def as_bool(value: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,10 @@ line-length = 120
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 0
+omit = [
+    "test/*",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ install_requires =
 test =
     parameterized>=0.8,<1
     codecov>=2.1.0
-    coverage>=5.2.0
+    coverage[toml]>=5.2.0
     unittest-xml-reporting>=3.0.0
     requests-mock>=1.8.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ install_requires =
 
 [options.extras_require]
 test =
+    parameterized>=0.8,<1
     codecov>=2.1.0
     coverage>=5.2.0
     unittest-xml-reporting>=3.0.0

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,9 @@
+import os
+
+# Purge environment variables to prevent them leaking from the user environment
+# into the test suite.
+PURGE_ENV_VARS = ["GRAFANA_URL", "GRAFANA_TOKEN"]
+
+for envvar in PURGE_ENV_VARS:
+    if envvar in os.environ:
+        del os.environ[envvar]

--- a/test/elements/test_annotations.py
+++ b/test/elements/test_annotations.py
@@ -19,7 +19,7 @@ class AnnotationsTestCase(unittest.TestCase):
     def test_annotations(self, m):
         m.get(
             "http://localhost/api/annotations?from=1563183710618&to=1563185212275"
-            "&alertId=11&dashboardId=111&panelId=22&tags=tags-test&limit=1",
+            "&alertId=11&dashboardId=111&panelId=22&userId=42&type=alert&tags=tags-test&limit=1",
             json=[
                 {
                     "id": 80,
@@ -27,7 +27,8 @@ class AnnotationsTestCase(unittest.TestCase):
                     "alertName": "",
                     "dashboardId": 111,
                     "panelId": 22,
-                    "userId": 0,
+                    "userId": 42,
+                    "type": "alert",
                     "newState": "",
                     "prevState": "",
                     "created": 1563280160455,
@@ -48,6 +49,8 @@ class AnnotationsTestCase(unittest.TestCase):
             alert_id=11,
             dashboard_id=111,
             panel_id=22,
+            user_id=42,
+            ann_type="alert",
             tags=["tags-test"],
             limit=1,
         )
@@ -55,6 +58,8 @@ class AnnotationsTestCase(unittest.TestCase):
         self.assertEqual(annotations[0]["alertId"], 11)
         self.assertEqual(annotations[0]["dashboardId"], 111)
         self.assertEqual(annotations[0]["panelId"], 22)
+        self.assertEqual(annotations[0]["userId"], 42)
+        self.assertEqual(annotations[0]["type"], "alert")
         self.assertEqual(annotations[0]["tags"][0], "tags-test")
 
         self.assertEqual(len(annotations), 1)

--- a/test/elements/test_datasource.py
+++ b/test/elements/test_datasource.py
@@ -1,15 +1,126 @@
 import json
 import unittest
+from unittest import mock
+from unittest.mock import Mock, patch
 
 import requests_mock
 
 from grafana_client import GrafanaApi
 from grafana_client.client import (
     GrafanaBadInputError,
+    GrafanaClient,
     GrafanaClientError,
     GrafanaServerError,
     GrafanaUnauthorizedError,
 )
+from grafana_client.model import DatasourceHealthResponse, DatasourceIdentifier
+
+PROMETHEUS_DATASOURCE = {
+    "id": 42,
+    "uid": "h8KkCLt7z",
+    "orgId": 1,
+    "name": "Prometheus",
+    "type": "prometheus",
+    "typeName": "Prometheus",
+    "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+    "access": "proxy",
+    "url": "http://localhost:9090",
+    "password": "",
+    "user": "",
+    "database": "",
+    "basicAuth": False,
+    "isDefault": True,
+    "jsonData": {"httpMethod": "POST"},
+    "readOnly": False,
+}
+
+INFLUXDB1_DATASOURCE = {
+    "id": 43,
+    "uid": "9ac78sdc2",
+    "name": "InfluxDB",
+    "type": "influxdb",
+    "access": "proxy",
+    "url": "http://localhost:8086",
+    "jsonData": {"httpMode": "POST", "version": "InfluxQL"},
+}
+
+ELASTICSEARCH_DATASOURCE = {
+    "id": 44,
+    "uid": "34inf2sdc",
+    "name": "Elasticsearch",
+    "type": "elasticsearch",
+    "access": "proxy",
+    "database": "bazqux",
+    "url": "http://localhost:9200",
+    "jsonData": {
+        "esVersion": "7.10.0",
+        "timeField": "@timestamp",
+    },
+}
+
+TESTDATA_DATASOURCE = {
+    "id": 45,
+    "uid": "439fngqr2",
+    "name": "Testdata",
+    "type": "testdata",
+    "access": "proxy",
+}
+
+PROMETHEUS_DATA_RESPONSE = {
+    "status": "success",
+    "data": {
+        "resultType": "matrix",
+        "result": [
+            {
+                "metric": {"__name__": "up", "instance": "localhost:9090", "job": "prometheus"},
+                "values": [
+                    [1644164339, "1"],
+                    [1644164399, "1"],
+                    [1644164459, "1"],
+                    [1644164519, "1"],
+                    [1644164579, "1"],
+                    [1644164639, "1"],
+                ],
+            }
+        ],
+    },
+}
+
+PROMETHEUS_HEALTH_RESPONSE = {
+    "results": {
+        "test": {
+            "frames": [
+                {
+                    "schema": {
+                        "name": "1+1",
+                        "refId": "test",
+                        "meta": {
+                            "type": "timeseries-many",
+                            "custom": {"resultType": "matrix"},
+                            "executedQueryString": "Expr: 1+1\nStep: 15s",
+                        },
+                        "fields": [
+                            {
+                                "name": "Time",
+                                "type": "time",
+                                "typeInfo": {"frame": "time.Time"},
+                                "config": {"interval": 15000},
+                            },
+                            {
+                                "name": "Value",
+                                "type": "number",
+                                "typeInfo": {"frame": "float64", "nullable": True},
+                                "labels": {},
+                                "config": {"displayNameFromDS": "1+1"},
+                            },
+                        ],
+                    },
+                    "data": {"values": [[0], [2]]},
+                }
+            ]
+        }
+    }
+}
 
 
 class DatasourceTestCase(unittest.TestCase):
@@ -17,27 +128,95 @@ class DatasourceTestCase(unittest.TestCase):
         self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
 
     @requests_mock.Mocker()
+    def test_health(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/foobar/health",
+            json={"message": "TwinMaker datasource successfully configured (For play.grafana.org)", "status": "OK"},
+        )
+
+        result = self.grafana.datasource.health("foobar")
+        self.assertEqual(result["status"], "OK")
+
+    @requests_mock.Mocker()
+    def test_get_datasource_by_id(self, m):
+        m.get(
+            "http://localhost/api/datasources/42",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        result = self.grafana.datasource.get(DatasourceIdentifier(id="42"))
+        self.assertEqual(result["type"], "prometheus")
+
+    @requests_mock.Mocker()
+    def test_get_datasource_by_uid(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        result = self.grafana.datasource.get(DatasourceIdentifier(uid="h8KkCLt7z"))
+        self.assertEqual(result["type"], "prometheus")
+
+    @requests_mock.Mocker()
+    def test_get_datasource_by_name(self, m):
+        m.get(
+            "http://localhost/api/datasources/name/Prometheus",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        result = self.grafana.datasource.get(DatasourceIdentifier(name="Prometheus"))
+        self.assertEqual(result["type"], "prometheus")
+
+    @requests_mock.Mocker()
+    def test_get_datasource_invalid(self, m):
+        self.assertRaises(KeyError, lambda: self.grafana.datasource.get(DatasourceIdentifier()))
+
+    @requests_mock.Mocker()
+    def test_create_datasource(self, m):
+        m.post(
+            "http://localhost/api/datasources",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        result = self.grafana.datasource.create_datasource(PROMETHEUS_DATASOURCE)
+        self.assertEqual(result["type"], "prometheus")
+
+    @requests_mock.Mocker()
+    def test_update_datasource(self, m):
+        m.put(
+            "http://localhost/api/datasources/42",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        result = self.grafana.datasource.update_datasource(42, PROMETHEUS_DATASOURCE)
+        self.assertEqual(result["type"], "prometheus")
+
+    @requests_mock.Mocker()
+    def test_delete_datasource_by_id(self, m):
+        m.delete("http://localhost/api/datasources/42", json={"message": "Data source deleted"})
+
+        result = self.grafana.datasource.delete_datasource_by_id(42)
+        self.assertEqual(result, {"message": "Data source deleted"})
+
+    @requests_mock.Mocker()
+    def test_delete_datasource_by_uid(self, m):
+        m.delete("http://localhost/api/datasources/uid/h8KkCLt7z", json={"message": "Data source deleted"})
+
+        result = self.grafana.datasource.delete_datasource_by_uid("h8KkCLt7z")
+        self.assertEqual(result, {"message": "Data source deleted"})
+
+    @requests_mock.Mocker()
+    def test_delete_datasource_by_name(self, m):
+        m.delete("http://localhost/api/datasources/name/Prometheus", json={"message": "Data source deleted"})
+
+        result = self.grafana.datasource.delete_datasource_by_name("Prometheus")
+        self.assertEqual(result, {"message": "Data source deleted"})
+
+    @requests_mock.Mocker()
     def test_find_datasource(self, m):
         m.get(
             "http://localhost/api/datasources/name/Prometheus",
-            json={
-                "id": 1,
-                "uid": "h8KkCLt7z",
-                "orgId": 1,
-                "name": "Prometheus",
-                "type": "prometheus",
-                "typeName": "Prometheus",
-                "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
-                "access": "proxy",
-                "url": "http://localhost:9090",
-                "password": "",
-                "user": "",
-                "database": "",
-                "basicAuth": False,
-                "isDefault": True,
-                "jsonData": {"httpMethod": "POST"},
-                "readOnly": False,
-            },
+            json=PROMETHEUS_DATASOURCE,
         )
 
         result = self.grafana.datasource.find_datasource("Prometheus")
@@ -56,35 +235,16 @@ class DatasourceTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_get_datasource_id_by_name(self, m):
-        m.get("http://localhost/api/datasources/id/Prometheus", json={"id": 1})
+        m.get("http://localhost/api/datasources/id/Prometheus", json={"id": 42})
 
         result = self.grafana.datasource.get_datasource_id_by_name("Prometheus")
-        self.assertEqual(result["id"], 1)
+        self.assertEqual(result["id"], 42)
 
     @requests_mock.Mocker()
     def test_list_datasources(self, m):
         m.get(
             "http://localhost/api/datasources",
-            json=[
-                {
-                    "id": 1,
-                    "uid": "h8KkCLt7z",
-                    "orgId": 1,
-                    "name": "Prometheus",
-                    "type": "prometheus",
-                    "typeName": "Prometheus",
-                    "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
-                    "access": "proxy",
-                    "url": "http://localhost:9090",
-                    "password": "",
-                    "user": "",
-                    "database": "",
-                    "basicAuth": False,
-                    "isDefault": True,
-                    "jsonData": {"httpMethod": "POST"},
-                    "readOnly": False,
-                }
-            ],
+            json=[PROMETHEUS_DATASOURCE],
         )
 
         result = self.grafana.datasource.list_datasources()
@@ -92,29 +252,28 @@ class DatasourceTestCase(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
     @requests_mock.Mocker()
-    def test_get_datasource_proxy_data(self, m):
+    def test_get_datasource_proxy_data_query(self, m):
+        # http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=up%7binstance%3d%22localhost:9090%22%7d&time=1644164339
+        m.get(
+            "http://localhost/api/datasources/proxy/1/api/v1/query",
+            json=PROMETHEUS_DATA_RESPONSE,
+        )
+        result = self.grafana.datasource.get_datasource_proxy_data(
+            1,  # datasource_id
+            query_type="query",
+            expr='up{instance="localhost:9090"}',
+            time=1644164339,
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"]["result"][0]["metric"]["job"], "prometheus")
+        self.assertEqual(len(result["data"]["result"][0]["values"]), 6)
+
+    @requests_mock.Mocker()
+    def test_get_datasource_proxy_data_query_range(self, m):
         # http://localhost:3000/api/datasources/proxy/1/api/v1/query_range?query=up%7binstance%3d%22localhost:9090%22%7d&start=1644164339&end=1644164639&step=60
         m.get(
             "http://localhost/api/datasources/proxy/1/api/v1/query_range",
-            json={
-                "status": "success",
-                "data": {
-                    "resultType": "matrix",
-                    "result": [
-                        {
-                            "metric": {"__name__": "up", "instance": "localhost:9090", "job": "prometheus"},
-                            "values": [
-                                [1644164339, "1"],
-                                [1644164399, "1"],
-                                [1644164459, "1"],
-                                [1644164519, "1"],
-                                [1644164579, "1"],
-                                [1644164639, "1"],
-                            ],
-                        }
-                    ],
-                },
-            },
+            json=PROMETHEUS_DATA_RESPONSE,
         )
         result = self.grafana.datasource.get_datasource_proxy_data(
             1,  # datasource_id
@@ -127,3 +286,401 @@ class DatasourceTestCase(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["data"]["result"][0]["metric"]["job"], "prometheus")
         self.assertEqual(len(result["data"]["result"][0]["values"]), 6)
+
+    @requests_mock.Mocker()
+    def test_query_with_datasource_prometheus(self, m):
+        m.post(
+            "http://localhost/api/ds/query",
+            json=PROMETHEUS_HEALTH_RESPONSE,
+        )
+        datasource = PROMETHEUS_DATASOURCE.copy()
+        response = self.grafana.datasource.query(datasource, "1+1")
+        self.assertEqual(response, PROMETHEUS_HEALTH_RESPONSE)
+
+    @requests_mock.Mocker()
+    def test_query_with_datasource_influxdb_influxql(self, m):
+        m.post(
+            "http://localhost/api/datasources/proxy/43/query",
+            json={},
+        )
+        datasource = INFLUXDB1_DATASOURCE.copy()
+        response = self.grafana.datasource.query(datasource, "SHOW RETENTION POLICIES on _internal", store="foobar")
+        # TODO: No response payload yet.
+
+    @requests_mock.Mocker()
+    def test_query_with_datasource_elasticsearch(self, m):
+        m.get(
+            "http://localhost/api/datasources/proxy/44/bazqux/_mapping",
+            json={},
+        )
+        datasource = ELASTICSEARCH_DATASOURCE.copy()
+        response = self.grafana.datasource.query(
+            datasource, "url:///datasources/proxy/44/bazqux/_mapping", store="bazqux"
+        )
+        # TODO: No response payload yet.
+
+    @requests_mock.Mocker()
+    def test_query_with_datasource_identifier(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z",
+            json=PROMETHEUS_DATASOURCE,
+        )
+        m.post(
+            "http://localhost/api/ds/query",
+            json=PROMETHEUS_HEALTH_RESPONSE,
+        )
+        response = self.grafana.datasource.query(DatasourceIdentifier(uid="h8KkCLt7z"), "1+1")
+        self.assertEqual(response, PROMETHEUS_HEALTH_RESPONSE)
+
+    def test_query_unknown_access_type_failure(self):
+        datasource = PROMETHEUS_DATASOURCE.copy()
+        datasource["access"] = "__UNKNOWN__"
+        self.assertRaises(NotImplementedError, lambda: self.grafana.datasource.query(datasource, expression="1+1"))
+
+    def test_query_empty_expression_failure(self):
+        datasource = PROMETHEUS_DATASOURCE.copy()
+        self.assertRaises(ValueError, lambda: self.grafana.datasource.query(datasource, expression=None))
+
+    @patch("grafana_client.client.GrafanaClient.__getattr__")
+    def test_query_client_error_failure(self, mock_get):
+
+        mock_get.return_value = Mock()
+        mock_get.return_value.side_effect = GrafanaClientError(status_code=400, response={}, message="Something failed")
+
+        datasource = PROMETHEUS_DATASOURCE.copy()
+        self.assertRaises(GrafanaClientError, lambda: self.grafana.datasource.query(datasource, expression="1+1"))
+
+    @patch("grafana_client.client.GrafanaClient.__getattr__")
+    def test_query_server_error_failure(self, mock_get):
+
+        mock_get.return_value = Mock()
+        mock_get.return_value.side_effect = GrafanaServerError(
+            status_code=500, response={}, message="Something serious failed"
+        )
+
+        datasource = PROMETHEUS_DATASOURCE.copy()
+        self.assertRaises(GrafanaServerError, lambda: self.grafana.datasource.query(datasource, expression="1+1"))
+
+
+class DatasourceHealthCheckTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+    @requests_mock.Mocker()
+    def test_health_check_elasticsearch(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/34inf2sdc",
+            json=ELASTICSEARCH_DATASOURCE,
+        )
+        m.get(
+            "http://localhost/api/datasources/proxy/44/bazqux/_mapping",
+            json={"bazqux": {"mappings": {"properties": "something"}}},
+        )
+        response = self.grafana.datasource.health_check(DatasourceIdentifier(uid="34inf2sdc"))
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="34inf2sdc",
+                type="elasticsearch",
+                success=True,
+                status="OK",
+                message="Success",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_check_influxdb1(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/9ac78sdc2",
+            json=INFLUXDB1_DATASOURCE,
+        )
+        m.post(
+            "http://localhost/api/datasources/proxy/43/query",
+            json={
+                "results": [
+                    {
+                        "statement_id": 0,
+                        "series": [
+                            {
+                                "columns": ["name", "duration", "shardGroupDuration", "replicaN", "default"],
+                                "values": [["monitor", "168h0m0s", "24h0m0s", 1, True]],
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        response = self.grafana.datasource.health_check(DatasourceIdentifier(uid="9ac78sdc2"))
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="9ac78sdc2",
+                type="influxdb",
+                success=True,
+                status="OK",
+                message="Success",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_check_prometheus(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z",
+            json=PROMETHEUS_DATASOURCE,
+        )
+        m.post(
+            "http://localhost/api/ds/query",
+            json=PROMETHEUS_HEALTH_RESPONSE,
+        )
+        response = self.grafana.datasource.health_check(DatasourceIdentifier(uid="h8KkCLt7z"))
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="h8KkCLt7z",
+                type="prometheus",
+                success=True,
+                status="OK",
+                message="Expr: 1+1\nStep: 15s",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_check_testdata(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/439fngqr2",
+            json=TESTDATA_DATASOURCE,
+        )
+        response = self.grafana.datasource.health_check(DatasourceIdentifier(uid="439fngqr2"))
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="439fngqr2",
+                type="testdata",
+                success=True,
+                status="OK",
+                message="Success",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_check_access_type_failure(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        datasource = PROMETHEUS_DATASOURCE.copy()
+        datasource["access"] = "__UNKNOWN__"
+        self.assertRaises(NotImplementedError, lambda: self.grafana.datasource.health_check(datasource))
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_native_prometheus_success(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en",
+            json={"type": "unknown"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en/health",
+            json={"status": "OK", "message": "Excellent!"},
+        )
+        response = self.grafana.datasource.health_inquiry(datasource_uid="39mf288en")
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="39mf288en",
+                type="unknown",
+                success=True,
+                status="OK",
+                message="Excellent!",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_native_prometheus_failure(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en",
+            json={"type": "unknown"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en/health",
+            json={"status": "ERROR", "message": "No way!"},
+        )
+        response = self.grafana.datasource.health_inquiry(datasource_uid="39mf288en")
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="39mf288en",
+                type="unknown",
+                success=False,
+                status="ERROR",
+                message="No way!",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_native_unknown_error_400(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en",
+            json={"type": "unknown"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en/health",
+            json={"status": "ERROR", "message": "Something failed"},
+            status_code=400,
+        )
+        response = self.grafana.datasource.health_inquiry(datasource_uid="39mf288en")
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="39mf288en",
+                type="unknown",
+                success=False,
+                status="ERROR",
+                message="Something failed",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_native_prometheus_error_404(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z",
+            json=PROMETHEUS_DATASOURCE,
+        )
+        m.post(
+            "http://localhost/api/ds/query",
+            json={"status": "ERROR", "message": "Something failed"},
+            status_code=404,
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z/health",
+            json={"status": "ERROR", "message": "Something failed"},
+            status_code=404,
+        )
+        response = self.grafana.datasource.health_inquiry(datasource_uid="h8KkCLt7z")
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="h8KkCLt7z",
+                type="prometheus",
+                success=False,
+                status="ERROR",
+                message="Unknown: Client Error 404: Something failed. Response: {'status': 'ERROR', 'message': 'Something failed'}",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_native_prometheus_error_500(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z",
+            json=PROMETHEUS_DATASOURCE,
+        )
+        m.post(
+            "http://localhost/api/ds/query",
+            json={"status": "ERROR", "message": "Something failed"},
+            status_code=500,
+        )
+        m.get(
+            "http://localhost/api/datasources/uid/h8KkCLt7z/health",
+            json={"status": "ERROR", "message": "Something failed"},
+            status_code=500,
+        )
+        self.assertRaises(
+            GrafanaServerError, lambda: self.grafana.datasource.health_inquiry(datasource_uid="h8KkCLt7z")
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_response_499(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en",
+            json={"status": "FATAL", "message": "Bad request"},
+            status_code=499,
+        )
+        self.assertRaises(
+            GrafanaClientError, lambda: self.grafana.datasource.health_inquiry(datasource_uid="39mf288en")
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_response_404(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en",
+            json={"status": "FATAL", "message": "Not found"},
+            status_code=404,
+        )
+        response = self.grafana.datasource.health_inquiry(datasource_uid="39mf288en")
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="39mf288en",
+                type=None,
+                success=False,
+                status="ERROR",
+                message="Not found",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_inquiry_response_500(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/39mf288en",
+            json={"status": "FATAL", "message": "Server failed"},
+            status_code=500,
+        )
+        self.assertRaises(
+            GrafanaServerError, lambda: self.grafana.datasource.health_inquiry(datasource_uid="39mf288en")
+        )

--- a/test/elements/test_user.py
+++ b/test/elements/test_user.py
@@ -1,0 +1,169 @@
+import unittest
+
+import requests_mock
+
+from grafana_client import GrafanaApi
+
+
+class UsersTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+    @requests_mock.Mocker()
+    def test_update_user(self, m):
+        m.put(
+            "http://localhost/api/users/foo",
+            json={},
+        )
+        user = self.grafana.users.update_user("foo", {})
+        self.assertEqual(user, {})
+
+    @requests_mock.Mocker()
+    def test_get_user(self, m):
+        m.get(
+            "http://localhost/api/users/foo",
+            json={},
+        )
+        user = self.grafana.users.get_user("foo")
+        self.assertEqual(user, {})
+
+    @requests_mock.Mocker()
+    def test_find_user(self, m):
+        m.get(
+            "http://localhost/api/users/lookup?loginOrEmail=foo",
+            json={},
+        )
+        user = self.grafana.users.find_user("foo")
+        self.assertEqual(user, {})
+
+    @requests_mock.Mocker()
+    def test_search_users_default(self, m):
+        m.get(
+            "http://localhost/api/users?query=foo&page=1",
+            json=[{"name": "foo"}, {"name": "bar"}],
+        )
+        m.get(
+            "http://localhost/api/users?query=foo&page=2",
+            json=[],
+        )
+        users = self.grafana.users.search_users("foo")
+        self.assertEqual(len(users), 2)
+
+    @requests_mock.Mocker()
+    def test_search_users_default_empty(self, m):
+        m.get(
+            "http://localhost/api/users?query=foo&page=1",
+            json=[],
+        )
+        users = self.grafana.users.search_users("foo")
+        self.assertEqual(len(users), 0)
+
+    @requests_mock.Mocker()
+    def test_search_users_page2(self, m):
+        m.get(
+            "http://localhost/api/users?query=foo&page=2",
+            json=[{}],
+        )
+        users = self.grafana.users.search_users("foo", page=2)
+        self.assertEqual(users, [{}])
+
+    @requests_mock.Mocker()
+    # FIXME: Runs into an endless loop.
+    #        See also https://github.com/panodata/grafana-client/issues/12.
+    def fixme_test_search_users_perpage(self, m):
+        m.get(
+            "http://localhost/api/users?query=foo&perpage=5",
+            json=[{}],
+        )
+        users = self.grafana.users.search_users("foo", perpage=5)
+        self.assertEqual(users, [{}])
+
+    @requests_mock.Mocker()
+    def test_search_users_perpage(self, m):
+        m.get(
+            "http://localhost/api/users?query=foo&page=1&perpage=1",
+            json=[{"name": "foo"}, {"name": "bar"}],
+        )
+        m.get(
+            "http://localhost/api/users?query=foo&page=2&perpage=1",
+            json=[],
+        )
+        users = self.grafana.users.search_users("foo", perpage=1)
+        self.assertEqual(len(users), 2)
+
+    @requests_mock.Mocker()
+    def test_get_user_organisations(self, m):
+        m.get(
+            "http://localhost/api/users/foo/orgs",
+            json=[],
+        )
+        users = self.grafana.users.get_user_organisations("foo")
+        self.assertEqual(users, [])
+
+
+class UserTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+    @requests_mock.Mocker()
+    def test_get_actual_user(self, m):
+        m.get(
+            "http://localhost/api/user",
+            json={},
+        )
+        result = self.grafana.user.get_actual_user()
+        self.assertEqual(result, {})
+
+    @requests_mock.Mocker()
+    def test_change_actual_user_password(self, m):
+        m.put(
+            "http://localhost/api/user/password",
+            json={},
+        )
+        result = self.grafana.user.change_actual_user_password("old", "new")
+        self.assertEqual(result, {})
+
+    @requests_mock.Mocker()
+    def test_switch_user_organisation(self, m):
+        m.post(
+            "http://localhost/api/users/foo/using/acme",
+            json={},
+        )
+        result = self.grafana.user.switch_user_organisation("foo", "acme")
+        self.assertEqual(result, {})
+
+    @requests_mock.Mocker()
+    def test_switch_actual_user_organisation(self, m):
+        m.post(
+            "http://localhost/api/user/using/acme",
+            json={},
+        )
+        result = self.grafana.user.switch_actual_user_organisation("acme")
+        self.assertEqual(result, {})
+
+    @requests_mock.Mocker()
+    def test_get_actual_user_organisations(self, m):
+        m.get(
+            "http://localhost/api/user/orgs",
+            json=[],
+        )
+        result = self.grafana.user.get_actual_user_organisations()
+        self.assertEqual(result, [])
+
+    @requests_mock.Mocker()
+    def test_star_actual_user_dashboard(self, m):
+        m.post(
+            "http://localhost/api/user/stars/dashboard/987vb7t33",
+            json={},
+        )
+        result = self.grafana.user.star_actual_user_dashboard("987vb7t33")
+        self.assertEqual(result, {})
+
+    @requests_mock.Mocker()
+    def test_unstar_actual_user_dashboard(self, m):
+        m.delete(
+            "http://localhost/api/user/stars/dashboard/987vb7t33",
+            json={},
+        )
+        result = self.grafana.user.unstar_actual_user_dashboard("987vb7t33")
+        self.assertEqual(result, {})

--- a/test/test_grafana_api.py
+++ b/test/test_grafana_api.py
@@ -1,0 +1,111 @@
+import os
+import unittest
+from unittest import mock
+
+import requests
+
+from grafana_client import GrafanaApi
+from grafana_client.client import TokenAuth
+
+
+class TestGrafanaApiFactories(unittest.TestCase):
+    """
+    Test the two factory methods, `GrafanaApi.from_url()`, and
+    `GrafanaApi.from_env()`, with different input parameters.
+    """
+
+    def test_from_url_default(self):
+        grafana = GrafanaApi.from_url()
+        self.assertIsInstance(grafana.client.auth, requests.auth.HTTPBasicAuth)
+        self.assertEqual(grafana.client.auth.username, "admin")
+        self.assertEqual(grafana.client.auth.password, "admin")
+        self.assertEqual(grafana.client.url_host, "localhost")
+        self.assertEqual(grafana.client.url_port, 3000)
+        self.assertEqual(grafana.client.url_path_prefix, "")
+        self.assertEqual(grafana.client.url_protocol, "http")
+        self.assertEqual(grafana.client.verify, True)
+        self.assertEqual(grafana.client.timeout, 5.0)
+
+    def test_from_url_anonymous(self):
+        grafana = GrafanaApi.from_url("http://localhost:3000")
+        self.assertEqual(grafana.client.auth, None)
+
+    def test_from_url_basicauth(self):
+        grafana = GrafanaApi.from_url(credential=("foo", "bar"))
+        self.assertIsInstance(grafana.client.auth, requests.auth.HTTPBasicAuth)
+        self.assertEqual(grafana.client.auth.username, "foo")
+        self.assertEqual(grafana.client.auth.password, "bar")
+
+    def test_from_url_tokenauth(self):
+        grafana = GrafanaApi.from_url(credential="VerySecretToken")
+        self.assertIsInstance(grafana.client.auth, TokenAuth)
+        self.assertEqual(grafana.client.auth.token, "VerySecretToken")
+
+    def test_from_url_auth_precedence(self):
+        grafana = GrafanaApi.from_url("http://foo:bar@localhost:3000", credential="VerySecretToken")
+        self.assertIsInstance(grafana.client.auth, TokenAuth)
+        self.assertEqual(grafana.client.auth.token, "VerySecretToken")
+
+    def test_from_url_auth_invalid(self):
+        self.assertRaises(TypeError, lambda: GrafanaApi.from_url("http://foo:bar@localhost:3000", credential=42.42))
+
+    def test_from_url_full_on(self):
+        grafana = GrafanaApi.from_url("https://foo:bar@daq.example.org/grafana/?verify=false")
+        self.assertIsInstance(grafana.client.auth, requests.auth.HTTPBasicAuth)
+        self.assertEqual(grafana.client.auth.username, "foo")
+        self.assertEqual(grafana.client.auth.password, "bar")
+        self.assertEqual(grafana.client.url_host, "daq.example.org")
+        self.assertEqual(grafana.client.url_port, None)
+        self.assertEqual(grafana.client.url_path_prefix, "grafana/")
+        self.assertEqual(grafana.client.url_protocol, "https")
+        self.assertEqual(grafana.client.verify, False)
+        self.assertEqual(grafana.client.timeout, 5.0)
+
+    def test_from_env_default(self):
+        grafana = GrafanaApi.from_env()
+        self.assertIsInstance(grafana.client.auth, requests.auth.HTTPBasicAuth)
+        self.assertEqual(grafana.client.auth.username, "admin")
+        self.assertEqual(grafana.client.auth.password, "admin")
+        self.assertEqual(grafana.client.url_host, "localhost")
+        self.assertEqual(grafana.client.url_port, 3000)
+        self.assertEqual(grafana.client.url_path_prefix, "")
+        self.assertEqual(grafana.client.url_protocol, "http")
+        self.assertEqual(grafana.client.verify, True)
+        self.assertEqual(grafana.client.timeout, 5.0)
+
+    @mock.patch.dict(os.environ, {"GRAFANA_URL": "http://localhost:3000"})
+    def test_from_env_anonymous(self):
+        grafana = GrafanaApi.from_env()
+        self.assertEqual(grafana.client.auth, None)
+
+    @mock.patch.dict(os.environ, {"GRAFANA_URL": "http://foo:bar@localhost:3000"})
+    def test_from_env_basicauth(self):
+        grafana = GrafanaApi.from_env()
+        self.assertIsInstance(grafana.client.auth, requests.auth.HTTPBasicAuth)
+        self.assertEqual(grafana.client.auth.username, "foo")
+        self.assertEqual(grafana.client.auth.password, "bar")
+
+    @mock.patch.dict(os.environ, {"GRAFANA_TOKEN": "VerySecretToken"})
+    def test_from_env_tokenauth(self):
+        grafana = GrafanaApi.from_env()
+        self.assertIsInstance(grafana.client.auth, TokenAuth)
+        self.assertEqual(grafana.client.auth.token, "VerySecretToken")
+
+    @mock.patch.dict(os.environ, {"GRAFANA_URL": "http://foo:bar@localhost:3000", "GRAFANA_TOKEN": "VerySecretToken"})
+    def test_from_env_auth_precedence(self):
+        grafana = GrafanaApi.from_env()
+        self.assertIsInstance(grafana.client.auth, TokenAuth)
+        self.assertEqual(grafana.client.auth.token, "VerySecretToken")
+
+    @mock.patch.dict(os.environ, {"GRAFANA_URL": "https://foo:bar@daq.example.org/grafana/?verify=false"})
+    def test_from_env_full_on(self):
+        grafana = GrafanaApi.from_env()
+        self.assertIsInstance(grafana.client.auth, requests.auth.HTTPBasicAuth)
+        self.assertEqual(grafana.client.auth.username, "foo")
+        self.assertEqual(grafana.client.auth.password, "bar")
+        self.assertEqual(grafana.client.url_host, "daq.example.org")
+        self.assertEqual(grafana.client.url_port, None)
+        self.assertEqual(grafana.client.url_path_prefix, "grafana/")
+        self.assertEqual(grafana.client.url_protocol, "https")
+        self.assertEqual(grafana.client.verify, False)
+        self.assertEqual(grafana.client.timeout, 5.0)

--- a/test/test_grafana_client.py
+++ b/test/test_grafana_client.py
@@ -9,7 +9,7 @@ else:
 import requests
 
 from grafana_client.api import GrafanaApi
-from grafana_client.client import TokenAuth
+from grafana_client.client import GrafanaClientError, TokenAuth
 
 
 class MockResponse:
@@ -94,6 +94,36 @@ class TestGrafanaClient(unittest.TestCase):
             protocol="https",
         )
         self.assertTrue(isinstance(grafana.client.auth, TokenAuth))
+
+    def test_tokenauth(self):
+        tokenauth = TokenAuth("VerySecretToken")
+        request = requests.Request()
+        tokenauth(request)
+        self.assertEqual(request.headers["Authorization"], "Bearer VerySecretToken")
+
+    @patch("grafana_client.client.GrafanaClient.__getattr__")
+    def test_grafana_client_connect_success(self, mock_get):
+        payload = {"commit": "14e988bd22", "database": "ok", "version": "9.0.1"}
+        mock_get.return_value = Mock()
+        mock_get.return_value.return_value = payload
+        grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
+        grafana_info = grafana.connect()
+        self.assertEqual(grafana_info, payload)
+
+    def test_grafana_client_connect_failure(self):
+        grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="32425")
+        self.assertRaises(requests.exceptions.ConnectionError, lambda: grafana.connect())
+
+    @patch("grafana_client.client.GrafanaClient.__getattr__")
+    def test_grafana_client_version(self, mock_get):
+        mock_get.return_value = Mock()
+        mock_get.return_value.return_value = {"commit": "14e988bd22", "database": "ok", "version": "9.0.1"}
+        grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
+        self.assertEqual(grafana.version, "9.0.1")
+
+    def test_grafana_client_non_json_response(self):
+        grafana = GrafanaApi.from_url("https://httpbin.org/html")
+        self.assertRaises(GrafanaClientError, lambda: grafana.connect())
 
 
 if __name__ == "__main__":

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -1,0 +1,73 @@
+import unittest
+
+from parameterized import parameterized
+
+from grafana_client.knowledge import (
+    datasource_factory,
+    get_healthcheck_expression,
+    query_factory,
+)
+from grafana_client.model import DatasourceModel
+
+SUPPORTED_DATA_SOURCE_TYPES = [
+    "cratedb",
+    "elasticsearch",
+    "influxdb",
+    "influxdb+influxql",
+    "influxdb+flux",
+    "postgres",
+    "prometheus",
+    "testdata",
+]
+
+
+SUPPORTED_DATA_SOURCE_TYPES_COMPAT = SUPPORTED_DATA_SOURCE_TYPES.copy()
+SUPPORTED_DATA_SOURCE_TYPES_COMPAT.remove("cratedb")
+
+
+class KnowledgebaseTestCase(unittest.TestCase):
+    @parameterized.expand(SUPPORTED_DATA_SOURCE_TYPES)
+    def test_datasource_factory_success(self, data_source_type):
+        ds = datasource_factory(DatasourceModel(name="foo", type=data_source_type, url=None, access=None))
+        self.assertIsInstance(ds, DatasourceModel)
+
+    def test_datasource_factory_unknown_failure(self):
+        self.assertRaises(
+            NotImplementedError,
+            lambda: datasource_factory(DatasourceModel(name="foo", type="unknown", url=None, access=None)),
+        )
+
+    @parameterized.expand(SUPPORTED_DATA_SOURCE_TYPES)
+    def test_query_factory_success(self, data_source_type):
+        ds = datasource_factory(DatasourceModel(name="foo", type=data_source_type, url=None, access=None))
+        query = query_factory(ds.asdict(), expression="bar")
+        self.assertIsInstance(query, (dict, str))
+
+    def test_query_factory_unknown_type_failure(self):
+        ds = datasource_factory(DatasourceModel(name="foo", type="prometheus", url=None, access=None))
+        ds.type = "unknown"
+        self.assertRaises(
+            NotImplementedError,
+            lambda: query_factory(ds.asdict(), expression="bar"),
+        )
+
+    def test_query_factory_unknown_influxdb_dialect_failure(self):
+        ds = datasource_factory(DatasourceModel(name="foo", type="influxdb", url=None, access=None))
+        ds.jsonData["version"] = "unknown"
+        self.assertRaises(
+            KeyError,
+            lambda: query_factory(ds.asdict(), expression="bar"),
+        )
+
+    @parameterized.expand(SUPPORTED_DATA_SOURCE_TYPES_COMPAT)
+    def test_get_healthcheck_expression_all(self, data_source_type):
+        result = get_healthcheck_expression(data_source_type)
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 1)
+
+    def test_get_healthcheck_expression_influxdb_flux(self):
+        result = get_healthcheck_expression("influxdb", "Flux")
+        self.assertEqual(result, "buckets()")
+
+    def test_get_healthcheck_expression_unknown_failure(self):
+        self.assertRaises(NotImplementedError, lambda: get_healthcheck_expression("foobar"))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,27 @@
+import unittest
+
+from grafana_client.model import DatasourceHealthResponse
+
+dhr = DatasourceHealthResponse(
+    uid="uid",
+    type="type",
+    success=True,
+    status="status",
+    message="message",
+    duration=42.42,
+    response={},
+)
+
+
+class ModelTestCase(unittest.TestCase):
+    def test_datasource_health_response_asdict(self):
+        data = dhr.asdict()
+        self.assertIsInstance(data, dict)
+        self.assertTrue(len(data) > 1)
+        self.assertIn("response", data)
+
+    def test_datasource_health_response_asdict_compact(self):
+        data = dhr.asdict_compact()
+        self.assertIsInstance(data, dict)
+        self.assertTrue(len(data) > 1)
+        self.assertNotIn("response", data)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,17 @@
+import logging
+import unittest
+
+from grafana_client.util import as_bool, setup_logging
+
+
+class UtilTestCase(unittest.TestCase):
+    def test_setup_logging(self):
+        setup_logging(level=logging.WARNING)
+
+    def test_as_bool_success(self):
+        self.assertTrue(as_bool("true"))
+        self.assertFalse(as_bool("false"))
+        self.assertFalse(as_bool(None))
+
+    def test_as_bool_failure(self):
+        self.assertRaises(ValueError, lambda: as_bool("foo"))


### PR DESCRIPTION
- Improve data source client convenience
- Improve data source health check subsystem
- Add new factory methods `GrafanaApi.from_url()` and `GrafanaApi.from_env()`
- Add `GrafanaApi.connect()` and `GrafanaApi.version()`
- Add some sensible example programs
- Add a bunch of software tests, bringing coverage up to speed again