### PR TITLE
Add more data source health check adapters: Jaeger, Loki, Microsoft SQL Server, Tempo, Zipkin

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ implemented as of June 2022.
 - Prometheus
 - Tempo
 - Testdata
+- Zipkin
 
 We are humbly asking the community to contribute adapters for other data
 sources.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ implemented as of June 2022.
 - InfluxDB
 - Jaeger
 - Loki
+- Microsoft SQL Server
 - OpenTSDB
 - PostgreSQL
 - Prometheus

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ implemented as of June 2022.
 - OpenTSDB
 - PostgreSQL
 - Prometheus
+- Tempo
 - Testdata
 
 We are humbly asking the community to contribute adapters for other data

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ implemented as of June 2022.
 - Elasticsearch
 - Graphite
 - InfluxDB
+- Jaeger
 - OpenTSDB
 - PostgreSQL
 - Prometheus

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ implemented as of June 2022.
 - Graphite
 - InfluxDB
 - Jaeger
+- Loki
 - OpenTSDB
 - PostgreSQL
 - Prometheus

--- a/docs/datasource-state.md
+++ b/docs/datasource-state.md
@@ -19,7 +19,6 @@ stackdriver
 testdata
 
 ### UNKNOWN
-jaeger
 loki
 mssql
 tempo

--- a/docs/datasource-state.md
+++ b/docs/datasource-state.md
@@ -20,7 +20,6 @@ testdata
 
 ### UNKNOWN
 mssql
-tempo
 zipkin
 
 ### TODO

--- a/docs/datasource-state.md
+++ b/docs/datasource-state.md
@@ -19,7 +19,6 @@ stackdriver
 testdata
 
 ### UNKNOWN
-loki
 mssql
 tempo
 zipkin

--- a/docs/datasource-state.md
+++ b/docs/datasource-state.md
@@ -19,7 +19,6 @@ stackdriver
 testdata
 
 ### UNKNOWN
-mssql
 zipkin
 
 ### TODO

--- a/docs/datasource-state.md
+++ b/docs/datasource-state.md
@@ -19,7 +19,6 @@ stackdriver
 testdata
 
 ### UNKNOWN
-zipkin
 
 ### TODO
 alertmanager

--- a/examples/datasource-health-probe.rst
+++ b/examples/datasource-health-probe.rst
@@ -157,6 +157,26 @@ MariaDB / MySQL
     python examples/datasource-health-probe.py --type=mysql --url=host.docker.internal:3306
 
 
+Microsoft SQL Server
+====================
+::
+
+    # Start service.
+    docker run --rm -it --publish=1433:1433 \
+        --env="ACCEPT_EULA=Y" --env="SA_PASSWORD=root123?" \
+        mcr.microsoft.com/mssql/server:2022-latest
+
+    # Create database `testdrive`.
+    docker run --rm -it --network=host mcr.microsoft.com/mssql/server:2022-latest /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "root123?" -Q "CREATE DATABASE testdrive;"
+
+    # Invoke Grafana database probe.
+    python examples/datasource-health-probe.py --type=mssql --url=host.docker.internal:1433
+
+Interactive client console::
+
+    docker run --rm -it --network=host mcr.microsoft.com/mssql/server:2022-latest /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P root123?
+
+
 OpenTSDB
 ========
 ::

--- a/examples/datasource-health-probe.rst
+++ b/examples/datasource-health-probe.rst
@@ -134,6 +134,14 @@ InfluxDB 2.x
     influx bucket list --org=example
 
 
+Jaeger
+======
+::
+
+    docker run --rm -it --name=jaeger --publish=16686:16686 jaegertracing/all-in-one:1
+    python examples/datasource-health-probe.py --type=jaeger --url=http://host.docker.internal:16686
+
+
 MariaDB / MySQL
 ===============
 ::

--- a/examples/datasource-health-probe.rst
+++ b/examples/datasource-health-probe.rst
@@ -181,6 +181,15 @@ Prometheus
     python examples/datasource-health-probe.py --type=prometheus --url=http://host.docker.internal:9090
 
 
+Tempo
+=====
+::
+
+    docker run --rm -it --name=tempo --publish=3200:80 grafana/tempo:1.4.1 \
+        --target=all --storage.trace.backend=local --storage.trace.local.path=/var/tempo --auth.enabled=false
+    python examples/datasource-health-probe.py --type=tempo --url=http://host.docker.internal:3200
+
+
 Testdata
 ========
 ::

--- a/examples/datasource-health-probe.rst
+++ b/examples/datasource-health-probe.rst
@@ -142,6 +142,13 @@ Jaeger
     python examples/datasource-health-probe.py --type=jaeger --url=http://host.docker.internal:16686
 
 
+Loki
+====
+::
+
+    docker run --rm -it --name=loki --publish=3100:3100 grafana/loki:2.5.0
+    python examples/datasource-health-probe.py --type=loki --url=http://host.docker.internal:3100
+
 MariaDB / MySQL
 ===============
 ::

--- a/examples/datasource-health-probe.rst
+++ b/examples/datasource-health-probe.rst
@@ -216,3 +216,10 @@ Testdata
 
     python examples/datasource-health-probe.py --type=testdata
 
+
+Zipkin
+======
+::
+
+    docker run --rm -it --publish=9411:9411 openzipkin/zipkin:2.23
+    python examples/datasource-health-probe.py --type=zipkin --url=http://host.docker.internal:9411

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -146,6 +146,10 @@ class GrafanaClient:
                         response,
                         "Client Error {0}: {1}".format(r.status_code, message),
                     )
-            return r.json()
+            # The "Tempo" data source responds with text/plain.
+            if r.headers.get("Content-Type", "").startswith("text/plain"):
+                return r.text
+            else:
+                return r.json()
 
         return __request_runner

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -349,6 +349,12 @@ class Datasource(Base):
                     message = "Success"
                     success = True
 
+            # With Zipkin, a 200 OK response with a JSON body containing an empty array is probably just fine.
+            elif datasource_type == "zipkin":
+                if response == []:
+                    message = "Success"
+                    success = True
+
             # Generic case, where the response has a top-level `results` or `data` key.
             else:
                 if "results" in response:

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -340,6 +340,8 @@ class Datasource(Base):
             else:
                 if "results" in response:
                     success, message = self.parse_health_response_results(response=response)
+                elif "data" in response:
+                    success, message = self.parse_health_response_data(response=response)
                 else:
                     message = f"Response lacks expected keys 'results' or 'data'"
 
@@ -540,5 +542,21 @@ class Datasource(Base):
                 message = f"FATAL: Unable to decode result from list-type response. {reason}"
         else:
             message = f"FATAL: Unknown response type '{type(results)}'. Expected: dictionary or list."
+
+        return success, message
+
+    @staticmethod
+    def parse_health_response_data(response: Dict) -> Tuple[bool, str]:
+        """
+        Response from Jaeger::
+
+            {"data":["jaeger-query"],"total":1,"limit":0,"offset":0,"errors":null}
+        """
+        success = False
+        message = str(response["data"])
+        if "errors" in response and response["errors"]:
+            message = str(response["errors"])
+        else:
+            success = True
 
         return success, message

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -343,6 +343,12 @@ class Datasource(Base):
                 message = "Success"
                 success = True
 
+            # With Tempo, a 200 OK response with a non-empty body is probably just fine.
+            elif datasource_type == "tempo":
+                if len(response) >= 0:
+                    message = "Success"
+                    success = True
+
             # Generic case, where the response has a top-level `results` or `data` key.
             else:
                 if "results" in response:

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -331,6 +331,13 @@ class Datasource(Base):
                     reason = f"{ex.__class__.__name__}: {ex}"
                     message = f"Invalid response. {reason}"
 
+            elif datasource_type == "loki":
+                if "status" in response and response["status"] == "success":
+                    message = "Success"
+                    success = True
+                else:
+                    message = response["message"]
+
             # With OpenTSDB, a 200 OK response with empty body is just fine.
             elif datasource_type == "opentsdb":
                 message = "Success"
@@ -551,6 +558,11 @@ class Datasource(Base):
         Response from Jaeger::
 
             {"data":["jaeger-query"],"total":1,"limit":0,"offset":0,"errors":null}
+
+        Response from Loki::
+
+            {"status":"success","data":["__name__"]}
+
         """
         success = False
         message = str(response["data"])

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -77,6 +77,19 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
         }
     elif datasource.type == "loki":
         datasource.access = "proxy"
+    elif datasource.type == "mssql":
+        datasource.access = "proxy"
+        datasource.database = "testdrive"
+        datasource.user = "sa"
+        datasource.jsonData = {
+            "authenticationType": "SQL Server Authentication",
+        }
+        datasource.secureJsonData = {
+            "password": "root123?",
+        }
+        datasource.secureJsonFields = {
+            "password": False,
+        }
     elif datasource.type == "mysql":
         datasource.user = "root"
         datasource.secureJsonData = {
@@ -149,6 +162,17 @@ def query_factory(datasource, expression: str, store: Optional[str] = None) -> U
         query = {}
     elif datasource_type == "loki":
         query = {}
+    elif datasource_type == "mssql":
+        query = {
+            "refId": "test",
+            "datasource": {
+                "type": datasource["type"],
+                "uid": datasource.get("uid"),
+            },
+            "datasourceId": datasource.get("id"),
+            "format": "table",
+            "rawSql": expression,
+        }
     elif datasource_type == "mysql":
         query = {
             "refId": "test",
@@ -219,6 +243,7 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "influxdb+flux": "buckets()",
     "jaeger": "url:///datasources/proxy/{datasource_id}/api/services",
     "loki": "url:///datasources/{datasource_id}/resources/labels?start=1656274994383000000&end=1656275594383000000",
+    "mssql": "SELECT 1",
     "mysql": "SELECT 1",
     "opentsdb": "url:///datasources/proxy/{datasource_id}/api/suggest?type=metrics&q=cpu&max=100",
     "postgres": "SELECT 1",

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -68,6 +68,8 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
         datasource.secureJsonFields = {
             "token": False,
         }
+    elif datasource.type == "jaeger":
+        datasource.access = "proxy"
     elif datasource.type == "opentsdb":
         datasource.access = "proxy"
         datasource.jsonData = {
@@ -139,6 +141,8 @@ def query_factory(datasource, expression: str, store: Optional[str] = None) -> U
             )
         else:
             raise KeyError(f"InfluxDB dialect '{dialect}' unknown")
+    elif datasource_type == "jaeger":
+        query = {}
     elif datasource_type == "mysql":
         query = {
             "refId": "test",
@@ -205,6 +209,7 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "influxdb": "SHOW RETENTION POLICIES on _internal",
     "influxdb+influxql": "SHOW RETENTION POLICIES on _internal",
     "influxdb+flux": "buckets()",
+    "jaeger": "url:///datasources/proxy/{datasource_id}/api/services",
     "mysql": "SELECT 1",
     "opentsdb": "url:///datasources/proxy/{datasource_id}/api/suggest?type=metrics&q=cpu&max=100",
     "postgres": "SELECT 1",

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -75,6 +75,8 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
         datasource.jsonData = {
             "tsdbVersion": 3,
         }
+    elif datasource.type == "loki":
+        datasource.access = "proxy"
     elif datasource.type == "mysql":
         datasource.user = "root"
         datasource.secureJsonData = {
@@ -143,6 +145,8 @@ def query_factory(datasource, expression: str, store: Optional[str] = None) -> U
             raise KeyError(f"InfluxDB dialect '{dialect}' unknown")
     elif datasource_type == "jaeger":
         query = {}
+    elif datasource_type == "loki":
+        query = {}
     elif datasource_type == "mysql":
         query = {
             "refId": "test",
@@ -210,6 +214,7 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "influxdb+influxql": "SHOW RETENTION POLICIES on _internal",
     "influxdb+flux": "buckets()",
     "jaeger": "url:///datasources/proxy/{datasource_id}/api/services",
+    "loki": "url:///datasources/{datasource_id}/resources/labels?start=1656274994383000000&end=1656275594383000000",
     "mysql": "SELECT 1",
     "opentsdb": "url:///datasources/proxy/{datasource_id}/api/suggest?type=metrics&q=cpu&max=100",
     "postgres": "SELECT 1",

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -107,6 +107,8 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
         datasource.access = "proxy"
     elif datasource.type == "testdata":
         pass
+    elif datasource.type == "zipkin":
+        datasource.access = "proxy"
     else:
         raise NotImplementedError(f"Unknown data source type: {datasource.type}")
     return datasource
@@ -226,6 +228,8 @@ def query_factory(datasource, expression: str, store: Optional[str] = None) -> U
         query = {}
     elif datasource_type == "testdata":
         query = expression
+    elif datasource_type == "zipkin":
+        query = {}
     else:
         raise NotImplementedError(f"Unknown data source type: {datasource_type}")
     return query
@@ -251,6 +255,7 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "simpod-json-datasource": "url:///datasources/proxy/{datasource_id}",
     "tempo": "url:///datasources/proxy/{datasource_id}/api/echo",
     "testdata": "url:///datasources/uid/{datasource_uid}",
+    "zipkin": "url:///datasources/proxy/{datasource_id}/api/v2/services",
 }
 
 

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -90,6 +90,8 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
         }
     elif datasource.type == "prometheus":
         datasource.access = "proxy"
+    elif datasource.type == "tempo":
+        datasource.access = "proxy"
     elif datasource.type == "testdata":
         pass
     else:
@@ -196,6 +198,8 @@ def query_factory(datasource, expression: str, store: Optional[str] = None) -> U
         }
     elif datasource_type == "simpod-json-datasource":
         query = expression
+    elif datasource_type == "tempo":
+        query = {}
     elif datasource_type == "testdata":
         query = expression
     else:
@@ -220,6 +224,7 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "postgres": "SELECT 1",
     "prometheus": "1+1",
     "simpod-json-datasource": "url:///datasources/proxy/{datasource_id}",
+    "tempo": "url:///datasources/proxy/{datasource_id}/api/echo",
     "testdata": "url:///datasources/uid/{datasource_uid}",
 }
 

--- a/test/elements/test_datasource_fixtures.py
+++ b/test/elements/test_datasource_fixtures.py
@@ -151,6 +151,14 @@ TESTDATA_DATASOURCE = {
     "access": "proxy",
 }
 
+ZIPKIN_DATASOURCE = {
+    "id": 57,
+    "uid": "3sXIv8q7k",
+    "name": "Zipkin",
+    "type": "zipkin",
+    "access": "proxy",
+}
+
 
 PROMETHEUS_DATA_RESPONSE = {
     "status": "success",

--- a/test/elements/test_datasource_fixtures.py
+++ b/test/elements/test_datasource_fixtures.py
@@ -48,6 +48,14 @@ LOKI_DATASOURCE = {
     "access": "proxy",
 }
 
+MSSQL_DATASOURCE = {
+    "id": 56,
+    "uid": "0pueH83nz",
+    "name": "MSSQL",
+    "type": "mssql",
+    "access": "proxy",
+}
+
 MYSQL_DATASOURCE = {
     "id": 51,
     "uid": "7CpzLp37z",

--- a/test/elements/test_datasource_fixtures.py
+++ b/test/elements/test_datasource_fixtures.py
@@ -127,6 +127,14 @@ SUNANDMOON_DATASOURCE = {
 SUNANDMOON_DATASOURCE_INCOMPLETE = deepcopy(SUNANDMOON_DATASOURCE)
 del SUNANDMOON_DATASOURCE_INCOMPLETE["jsonData"]["latitude"]
 
+TEMPO_DATASOURCE = {
+    "id": 55,
+    "uid": "aTk86s3nk",
+    "name": "Tempo",
+    "type": "tempo",
+    "access": "proxy",
+}
+
 TESTDATA_DATASOURCE = {
     "id": 45,
     "uid": "439fngqr2",

--- a/test/elements/test_datasource_fixtures.py
+++ b/test/elements/test_datasource_fixtures.py
@@ -40,6 +40,14 @@ JAEGER_DATASOURCE = {
     "access": "proxy",
 }
 
+LOKI_DATASOURCE = {
+    "id": 54,
+    "uid": "vCyglaq7z",
+    "name": "Loki",
+    "type": "loki",
+    "access": "proxy",
+}
+
 MYSQL_DATASOURCE = {
     "id": 51,
     "uid": "7CpzLp37z",

--- a/test/elements/test_datasource_fixtures.py
+++ b/test/elements/test_datasource_fixtures.py
@@ -32,6 +32,14 @@ INFLUXDB1_DATASOURCE = {
     "jsonData": {"httpMode": "POST", "version": "InfluxQL"},
 }
 
+JAEGER_DATASOURCE = {
+    "id": 53,
+    "uid": "DbtFe237k",
+    "name": "Jaeger",
+    "type": "jaeger",
+    "access": "proxy",
+}
+
 MYSQL_DATASOURCE = {
     "id": 51,
     "uid": "7CpzLp37z",

--- a/test/elements/test_datasource_health.py
+++ b/test/elements/test_datasource_health.py
@@ -9,6 +9,7 @@ from test.elements.test_datasource_fixtures import (
     INFLUXDB1_DATASOURCE,
     JAEGER_DATASOURCE,
     LOKI_DATASOURCE,
+    MSSQL_DATASOURCE,
     MYSQL_DATASOURCE,
     OPENTSDB_DATASOURCE,
     POSTGRES_DATASOURCE,
@@ -370,6 +371,32 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
                 success=False,
                 status="ERROR",
                 message="Failed to call resource",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_check_mssql(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/0pueH83nz",
+            json=MSSQL_DATASOURCE,
+        )
+        m.post(
+            "http://localhost/api/ds/query",
+            json=DATAFRAME_RESPONSE_HEALTH_SELECT1,
+        )
+        response = self.grafana.datasource.health_check(DatasourceIdentifier(uid="0pueH83nz"))
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="0pueH83nz",
+                type="mssql",
+                success=True,
+                status="OK",
+                message="SELECT 1",
                 duration=None,
                 response=None,
             ),

--- a/test/elements/test_datasource_health.py
+++ b/test/elements/test_datasource_health.py
@@ -20,6 +20,7 @@ from test.elements.test_datasource_fixtures import (
     SUNANDMOON_DATASOURCE_INCOMPLETE,
     TEMPO_DATASOURCE,
     TESTDATA_DATASOURCE,
+    ZIPKIN_DATASOURCE,
 )
 
 import requests_mock
@@ -723,6 +724,32 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
             DatasourceHealthResponse(
                 uid="439fngqr2",
                 type="testdata",
+                success=True,
+                status="OK",
+                message="Success",
+                duration=None,
+                response=None,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_health_check_zipkin_success(self, m):
+        m.get(
+            "http://localhost/api/datasources/uid/3sXIv8q7k",
+            json=ZIPKIN_DATASOURCE,
+        )
+        m.get(
+            "http://localhost/api/datasources/proxy/57/api/v2/services",
+            json=[],
+        )
+        response = self.grafana.datasource.health_check(DatasourceIdentifier(uid="3sXIv8q7k"))
+        response.duration = None
+        response.response = None
+        self.assertEqual(
+            response,
+            DatasourceHealthResponse(
+                uid="3sXIv8q7k",
+                type="zipkin",
                 success=True,
                 status="OK",
                 message="Success",

--- a/test/test_grafana_client.py
+++ b/test/test_grafana_client.py
@@ -13,9 +13,10 @@ from grafana_client.client import GrafanaClientError, TokenAuth
 
 
 class MockResponse:
-    def __init__(self, json_data, status_code):
+    def __init__(self, json_data, status_code, headers=None):
         self.json_data = json_data
         self.status_code = status_code
+        self.headers = headers or {"Content-Type": "application/json"}
 
     def json(self):
         return self.json_data


### PR DESCRIPTION
This patch adds data source health check adapters for Jaeger, Loki, Microsoft SQL Server, Tempo, and Zipkin, including corresponding software tests. It also includes documentation how to start the corresponding data source instances using Docker.

Reference: #20.