### PR TITLE
feat: allow updating the folder UID

### DIFF
--- a/grafana_client/elements/folder.py
+++ b/grafana_client/elements/folder.py
@@ -48,16 +48,18 @@ class Folder(Base):
         """
         body = {}
         if new_uid:
-            body['uid'] = new_uid
+            body["uid"] = new_uid
         if title:
-            body['title'] = title
+            body["title"] = title
         if version:
             body["version"] = version
         if overwrite:
             body["overwrite"] = True
+        print(body)
 
         path = "/folders/%s" % uid
         r = self.client.PUT(path, json=body)
+        print(r)
         return r
 
     def delete_folder(self, uid):

--- a/grafana_client/elements/folder.py
+++ b/grafana_client/elements/folder.py
@@ -37,7 +37,7 @@ class Folder(Base):
             json_data["uid"] = uid
         return self.client.POST("/folders", json=json_data)
 
-    def update_folder(self, uid, title, version=None, overwrite=False):
+    def update_folder(self, uid, new_uid=None, title=None, version=None, overwrite=False):
         """
 
         :param uid:
@@ -46,8 +46,12 @@ class Folder(Base):
         :param overwrite:
         :return:
         """
-        body = {"title": title}
-        if version is not None:
+        body = {}
+        if new_uid:
+            body['uid'] = new_uid
+        if title:
+            body['title'] = title
+        if version:
             body["version"] = version
         if overwrite:
             body["overwrite"] = True

--- a/test/elements/test_folder.py
+++ b/test/elements/test_folder.py
@@ -108,8 +108,11 @@ class FolderTestCase(unittest.TestCase):
                 "version": 1,
             },
         )
-        folder = self.grafana.folder.update_folder(title="Departmenet DEF", uid="nErXDvCkzz", version=1, overwrite=True)
+        folder = self.grafana.folder.update_folder(
+            title="Departmenet DEF", uid="nErXDvCkzz", new_uid="nErXDvCkzz", version=1, overwrite=True
+        )
         self.assertEqual(folder["title"], "Departmenet DEF")
+        self.assertEqual(folder["uid"], "nErXDvCkzz")
 
     @requests_mock.Mocker()
     def test_update_folder_some_param(self, m):


### PR DESCRIPTION
Signed-off-by: Noah Krause <krausenoah@gmail.com>

## Description
<!-- Please include a summary of the change or which issue is fixed (fixes #(issue)). -->
Updates the `update_folder` method of the `folder` API to allow changing the UID of the folder.

Just adding an additional argument to the method was done for backwards compatibility. Passing in a dictionary of the folder elements to be changed would have been a preferred solution to support the upstream API long-term.

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
