### PR TITLE
feat: allow updating the folder UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Update the `update_folder` method of the folder API to allow changing
+  the UID of the folder. Thanks, @iNoahNothing.
+
 
 ## 3.0.0 (2022-07-02)
 

--- a/grafana_client/elements/folder.py
+++ b/grafana_client/elements/folder.py
@@ -37,17 +37,22 @@ class Folder(Base):
             json_data["uid"] = uid
         return self.client.POST("/folders", json=json_data)
 
-    def update_folder(self, uid, title, version=None, overwrite=False):
+    def update_folder(self, uid, title=None, version=None, overwrite=False, new_uid=None):
         """
 
         :param uid:
         :param title:
         :param version:
         :param overwrite:
+        :param new_uid:
         :return:
         """
-        body = {"title": title}
-        if version is not None:
+        body = {}
+        if new_uid:
+            body["uid"] = new_uid
+        if title:
+            body["title"] = title
+        if version:
             body["version"] = version
         if overwrite:
             body["overwrite"] = True

--- a/test/elements/test_folder.py
+++ b/test/elements/test_folder.py
@@ -110,6 +110,33 @@ class FolderTestCase(unittest.TestCase):
         )
         folder = self.grafana.folder.update_folder(title="Departmenet DEF", uid="nErXDvCkzz", version=1, overwrite=True)
         self.assertEqual(folder["title"], "Departmenet DEF")
+        self.assertEqual(folder["uid"], "nErXDvCkzz")
+
+    @requests_mock.Mocker()
+    def test_update_folder_uid(self, m):
+        m.put(
+            "http://localhost/api/folders/nErXDvCkzz",
+            json={
+                "id": 1,
+                "uid": "oFsYEwDlaa",
+                "title": "Departmenet DEF",
+                "url": "/dashboards/f/oFsYEwDlaa/department-def",
+                "hasAcl": "false",
+                "canSave": "false",
+                "canEdit": "false",
+                "canAdmin": "false",
+                "createdBy": "admin",
+                "created": "2018-01-31T17:43:12+01:00",
+                "updatedBy": "admin",
+                "updated": "2018-01-31T17:43:12+01:00",
+                "version": 1,
+            },
+        )
+        folder = self.grafana.folder.update_folder(
+            title="Departmenet DEF", uid="nErXDvCkzz", new_uid="oFsYEwDlaa", version=1, overwrite=True
+        )
+        self.assertEqual(folder["title"], "Departmenet DEF")
+        self.assertEqual(folder["uid"], "oFsYEwDlaa")
 
     @requests_mock.Mocker()
     def test_update_folder_some_param(self, m):


### PR DESCRIPTION
This patch improves the `update_folder` method of the `folder` API to allow changing the UID of the folder. It is a followup to #32 by @iNoahNothing, with some additional refinements. Thank you again!

Signed-off-by: Noah Krause <krausenoah@gmail.com>
