### PR TITLE
Add `update_datasource_by_uid` to the datasource API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update the `update_folder` method of the folder API to allow changing
   the UID of the folder. Thanks, @iNoahNothing.
+* Add `update_datasource_by_uid` to the datasource API. Thanks, @mgreen-sm.
 
 
 ## 3.0.0 (2022-07-02)

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -124,6 +124,17 @@ class Datasource(Base):
         r = self.client.PUT(update_datasource, json=datasource)
         return r
 
+    def update_datasource_by_uid(self, datasource_uid, datasource):
+        """
+
+        :param datasource_uid:
+        :param datasource:
+        :return:
+        """
+        update_datasource = "/datasources/uid/%s" % datasource_uid
+        r = self.client.PUT(update_datasource, json=datasource)
+        return r
+
     def list_datasources(self):
         """
 

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -88,6 +88,16 @@ class DatasourceTestCase(unittest.TestCase):
         self.assertEqual(result["type"], "prometheus")
 
     @requests_mock.Mocker()
+    def test_update_datasource_by_uid(self, m):
+        m.put(
+            "http://localhost/api/datasources/uid/foo42",
+            json=PROMETHEUS_DATASOURCE,
+        )
+
+        result = self.grafana.datasource.update_datasource_by_uid("foo42", PROMETHEUS_DATASOURCE)
+        self.assertEqual(result["type"], "prometheus")
+
+    @requests_mock.Mocker()
     def test_delete_datasource_by_id(self, m):
         m.delete("http://localhost/api/datasources/42", json={"message": "Data source deleted"})
 


### PR DESCRIPTION
This patch implements the suggestion by @mgreen-sm and will resolve #33. Thank you!

It adds an `update_datasource_by_uid` function to the datasource API. See [Update an existing data source](https://grafana.com/docs/grafana/v9.0/developers/http_api/data_source/#update-an-existing-data-source) Grafana API documentation.


