### PR TITLE
Add `HeaderAuth` authentication mechanism: Authenticate with an arbitrary HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Update the `update_folder` method of the folder API to allow changing
   the UID of the folder. Thanks, @iNoahNothing.
 * Add `update_datasource_by_uid` to the datasource API. Thanks, @mgreen-sm.
+* Add `HeaderAuth` authentication mechanism, using an arbitrary HTTP header for
+  authentication, where the user can specify both its name and value. Thanks, @l0tzi.
 
 
 ## 3.0.0 (2022-07-02)

--- a/README.md
+++ b/README.md
@@ -84,28 +84,43 @@ exercises could be useful for others, don't hesitate to share them back.
 
 ## Authentication
 
-There are two ways to authenticate to the Grafana API. Either use an API token,
-or HTTP basic auth.
+There are several ways to authenticate to the Grafana HTTP API.
 
-To use the admin API, you need to use HTTP Basic Authentication, as stated at
-the [Grafana Admin API documentation].
+1. Anonymous access
+2. Grafana API token
+3. HTTP Basic Authentication
+4. HTTP Header Authentication
+
+The [Grafana Admin API] is a subset of the Grafana API. For accessing those API
+resources, you will need to use HTTP Basic Authentication.
 
 ```python
-from grafana_client import GrafanaApi
+from grafana_client import GrafanaApi, HeaderAuth, TokenAuth
 
-# Use Grafana API token.
+# 1. Anonymous access
 grafana = GrafanaApi.from_url(
     url="https://daq.example.org/grafana/",
-    credential="eyJrIjoiWHg...dGJpZCI6MX0=",
 )
 
-# Use HTTP basic authentication.
+# 2. Use Grafana API token.
+grafana = GrafanaApi.from_url(
+    url="https://daq.example.org/grafana/",
+    credential=TokenAuth(token="eyJrIjoiWHg...dGJpZCI6MX0="),
+)
+
+# 3. Use HTTP basic authentication.
 grafana = GrafanaApi.from_url(
     url="https://username:password@daq.example.org/grafana/",
 )
 grafana = GrafanaApi.from_url(
     url="https://daq.example.org/grafana/",
     credential=("username", "password")
+)
+
+# 4. Use HTTP Header authentication.
+grafana = GrafanaApi.from_url(
+    url="https://daq.example.org/grafana/",
+    credential=HeaderAuth(name="X-WEBAUTH-USER", value="foobar"),
 )
 
 # Optionally turn off TLS certificate verification.
@@ -116,6 +131,10 @@ grafana = GrafanaApi.from_url(
 # Use `GRAFANA_URL` and `GRAFANA_TOKEN` environment variables.
 grafana = GrafanaApi.from_env()
 ```
+
+Please note that, on top of the specific examples above, the object obtained by
+`credential` can be an arbitrary `requests.auth.AuthBase` instance.
+
 
 ## Proxy
 
@@ -265,6 +284,6 @@ poe test
 [examples folder]: https://github.com/panodata/grafana-client/tree/main/examples
 [future maintenance of `grafana_api`]: https://github.com/m0nhawk/grafana_api/issues/88
 [grafana_api]: https://github.com/m0nhawk/grafana_api
-[Grafana Admin API documentation]: https://grafana.com/docs/grafana/latest/http_api/admin/
+[Grafana Admin API]: https://grafana.com/docs/grafana/latest/http_api/admin/
 [Grafana HTTP API reference]: https://grafana.com/docs/grafana/latest/http_api/
 [LICENSE]: https://github.com/panodata/grafana-client/blob/main/LICENSE

--- a/grafana_client/__init__.py
+++ b/grafana_client/__init__.py
@@ -7,6 +7,7 @@ except ModuleNotFoundError:  # pragma:nocover
 
 warnings.filterwarnings("ignore", category=Warning, message="distutils Version classes are deprecated")
 from .api import GrafanaApi  # noqa:F401
+from .client import HeaderAuth, TokenAuth  # noqa:F401
 
 __appname__ = "grafana-client"
 

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -6,6 +6,7 @@ from typing import Tuple, Union
 from urllib.parse import parse_qs, urlparse
 
 import requests
+import requests.auth
 from urllib3.exceptions import InsecureRequestWarning
 
 from .client import GrafanaClient
@@ -88,7 +89,7 @@ class GrafanaApi:
         return version
 
     @classmethod
-    def from_url(cls, url: str = None, credential: Union[str, Tuple[str, str]] = None):
+    def from_url(cls, url: str = None, credential: Union[str, Tuple[str, str], requests.auth.AuthBase] = None):
         """
         Factory method to create a `GrafanaApi` instance from a URL.
 
@@ -100,7 +101,7 @@ class GrafanaApi:
         if url is None:
             url = "http://admin:admin@localhost:3000"
 
-        if credential is not None and not isinstance(credential, (str, Tuple)):
+        if credential is not None and not isinstance(credential, (str, Tuple, requests.auth.AuthBase)):
             raise TypeError(f"Argument 'credential' has wrong type: {type(credential)}")
 
         original_url = url

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -54,6 +54,16 @@ class TokenAuth(requests.auth.AuthBase):
         return request
 
 
+class HeaderAuth(requests.auth.AuthBase):
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def __call__(self, request):
+        request.headers.update({self.name: self.value})
+        return request
+
+
 class GrafanaClient:
     def __init__(
         self,
@@ -98,10 +108,12 @@ class GrafanaClient:
         self.s = requests.Session()
         self.s.headers["User-Agent"] = self.user_agent
         if self.auth is not None:
-            if not isinstance(self.auth, tuple):
-                self.auth = TokenAuth(self.auth)
-            else:
+            if isinstance(self.auth, requests.auth.AuthBase):
+                pass
+            elif isinstance(self.auth, tuple):
                 self.auth = requests.auth.HTTPBasicAuth(*self.auth)
+            else:
+                self.auth = TokenAuth(self.auth)
 
     def __getattr__(self, item):
         def __request_runner(url, json=None, data=None, headers=None):

--- a/test/test_grafana_api.py
+++ b/test/test_grafana_api.py
@@ -4,8 +4,7 @@ from unittest import mock
 
 import requests
 
-from grafana_client import GrafanaApi
-from grafana_client.client import TokenAuth
+from grafana_client import GrafanaApi, HeaderAuth, TokenAuth
 
 
 class TestGrafanaApiFactories(unittest.TestCase):
@@ -40,6 +39,12 @@ class TestGrafanaApiFactories(unittest.TestCase):
         grafana = GrafanaApi.from_url(credential="VerySecretToken")
         self.assertIsInstance(grafana.client.auth, TokenAuth)
         self.assertEqual(grafana.client.auth.token, "VerySecretToken")
+
+    def test_from_url_headerauth(self):
+        grafana = GrafanaApi.from_url(credential=HeaderAuth(name="X-WEBAUTH-USER", value="foobar"))
+        self.assertIsInstance(grafana.client.auth, HeaderAuth)
+        self.assertEqual(grafana.client.auth.name, "X-WEBAUTH-USER")
+        self.assertEqual(grafana.client.auth.value, "foobar")
 
     def test_from_url_auth_precedence(self):
         grafana = GrafanaApi.from_url("http://foo:bar@localhost:3000", credential="VerySecretToken")

--- a/test/test_grafana_client.py
+++ b/test/test_grafana_client.py
@@ -9,7 +9,7 @@ else:
 import requests
 
 from grafana_client.api import GrafanaApi
-from grafana_client.client import GrafanaClientError, TokenAuth
+from grafana_client.client import GrafanaClientError, HeaderAuth, TokenAuth
 
 
 class MockResponse:
@@ -117,6 +117,12 @@ class TestGrafanaClient(unittest.TestCase):
         request = requests.Request()
         tokenauth(request)
         self.assertEqual(request.headers["Authorization"], "Bearer VerySecretToken")
+
+    def test_headerauth(self):
+        headerauth = HeaderAuth(name="X-WEBAUTH-USER", value="foobar")
+        request = requests.Request()
+        headerauth(request)
+        self.assertEqual(request.headers["X-WEBAUTH-USER"], "foobar")
 
     @patch("grafana_client.client.GrafanaClient.__getattr__")
     def test_grafana_client_connect_success(self, mock_get):


### PR DESCRIPTION
## About
This patch implements the suggestion #31 by @l0tzi, to make it possible to authenticate with an arbitrary HTTP header, where the user can specify both its name and value, like:

> For our use case, it is only necessary to set `X-WEBAUTH-USER`  of the request header:
> ```python
> request.headers.update({'X-WEBAUTH-USER': user})
> ```

## Synopsis
```python
from grafana_client import GrafanaApi, HeaderAuth

grafana = GrafanaApi.from_url(
    url="https://daq.example.org/grafana/",
    credential=HeaderAuth(name="X-WEBAUTH-USER", value="foobar"),
)
```
