### PR TITLE
Fix handling `204 No Content` responses from Grafana HTTP API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## unreleased
 
 
+## 3.2.1 (2022-11-01)
+
+* Fix handling `204 No Content` responses from Grafana HTTP API.
+
+
 ## 3.2.0 (2022-11-01)
 
 * Implement foundation for accessing the Alerting Provisioning API.

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -158,6 +158,12 @@ class GrafanaClient:
                         response,
                         "Client Error {0}: {1}".format(r.status_code, message),
                     )
+
+            # `204 No Content` responses have an empty response body,
+            # so it doesn't decode well from JSON.
+            if r.status_code == 204:
+                return None
+
             # The "Tempo" data source responds with text/plain.
             if r.headers.get("Content-Type", "").startswith("text/"):
                 return r.text

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ develop =
     build<1
     poethepoet<1
     pip-review<2  # Use `pip-review --local --interactive` to upgrade outdated packages.
-    ruff==0.0.79;python_version>='3.7'
+    ruff==0.0.94;python_version>='3.7'
 
 
 [options.packages.find]


### PR DESCRIPTION
This patch is an aftermath to #39/#41, as an improved version to what had been removed with ebc2c0e0dd. See also https://github.com/panodata/grafana-client/issues/30#issuecomment-1299312635.