### PR TITLE
Improve organization- and team-preferences, add support for user-preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,8 @@ venv.bak/
 # visual code launch...
 .vscode/*
 
+# pytest
+.pytest_cache
+
 # ruff
 .ruff_cache

--- a/README.md
+++ b/README.md
@@ -268,13 +268,19 @@ The issue tracker URL is: https://github.com/panodata/grafana-client/issues
 In order to create a development sandbox, you may want to follow this list of
 commands. When you see the software tests succeed, you should be ready to start
 hacking.
+
 ```shell
 git clone https://github.com/panodata/grafana-client
 cd grafana-client
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --editable=.[test,develop]
+
+# Run all tests.
 poe test
+
+# Run specific tests.
+python -m unittest -k preference -vvv
 ```
 
 ## License

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+
+    project:
+      default:
+        target: 85%
+
+    patch:
+      default:
+        informational: true

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -66,7 +66,7 @@ class GrafanaApi:
         self.folder = Folder(self.client)
         self.health = Health(self.client)
         self.organization = Organization(self.client)
-        self.organizations = Organizations(self.client)
+        self.organizations = Organizations(self.client, self)
         self.search = Search(self.client)
         self.user = User(self.client)
         self.users = Users(self.client)

--- a/grafana_client/elements/organization.py
+++ b/grafana_client/elements/organization.py
@@ -1,3 +1,6 @@
+import warnings
+
+from ..model import UserOrganizationPreferences
 from .base import Base
 
 
@@ -180,9 +183,8 @@ class Organizations(Base):
         """
         :return:
         """
-        update_preference = "/org/preferences"
-        r = self.client.GET(update_preference)
-        return r
+        warnings.warn("Deprecated, please use `organization_preferences_get`", DeprecationWarning)
+        return self.organization_preferences_get()
 
     def organization_preference_update(self, theme="", home_dashboard_id=0, timezone="utc"):
         """
@@ -192,13 +194,57 @@ class Organizations(Base):
         :param timezone:
         :return:
         """
+        warnings.warn("Deprecated, please use `organization_preferences_update`", DeprecationWarning)
+        preferences = UserOrganizationPreferences(theme=theme, homeDashboardId=home_dashboard_id, timezone=timezone)
+        return self.organization_preferences_update(preferences)
+
+    def organization_preferences_get(self):
+        """
+        Retrieve preferences of current organization.
+
+        :return:
+        """
         update_preference = "/org/preferences"
+        r = self.client.GET(update_preference)
+        return r
+
+    def organization_preferences_update(self, preferences: UserOrganizationPreferences):
+        """
+        Update preferences of current organization as a whole.
+
+        From the `preferences` instance, only attributes with values `not None` will be submitted.
+        However, Grafana will reset all undefined attributes to its internal defaults.
+
+        If you want to update specific preference attributes, without touching the others,
+        please use the `organization_preferences_patch` method.
+
+        :param preferences:
+        :return:
+        """
+        update_preference = "/org/preferences"
+        data = preferences.asdict(filter_none=True)
+
         r = self.client.PUT(
             update_preference,
-            json={
-                "theme": theme,
-                "homeDashboardId": home_dashboard_id,
-                "timezone": timezone,
-            },
+            json=data,
+        )
+        return r
+
+    def organization_preferences_patch(self, preferences: UserOrganizationPreferences):
+        """
+        Update specific preferences of current organization.
+
+        From the `preferences` instance, only attributes with values `not None` will be submitted
+        and updated.
+
+        :param preferences:
+        :return:
+        """
+        update_preference = "/org/preferences"
+        data = preferences.asdict(filter_none=True)
+
+        r = self.client.PATCH(
+            update_preference,
+            json=data,
         )
         return r

--- a/grafana_client/elements/organization.py
+++ b/grafana_client/elements/organization.py
@@ -183,8 +183,8 @@ class Organizations(Base):
         """
         :return:
         """
-        warnings.warn("Deprecated, please use `organization_preferences_get`", DeprecationWarning)
-        return self.organization_preferences_get()
+        warnings.warn("This method is deprecated, please use `get_preferences`", DeprecationWarning)
+        return self.get_preferences()
 
     def organization_preference_update(self, theme="", home_dashboard_id=0, timezone="utc"):
         """
@@ -194,11 +194,11 @@ class Organizations(Base):
         :param timezone:
         :return:
         """
-        warnings.warn("Deprecated, please use `organization_preferences_update`", DeprecationWarning)
+        warnings.warn("This method is deprecated, please use `update_preferences`", DeprecationWarning)
         preferences = PersonalPreferences(theme=theme, homeDashboardId=home_dashboard_id, timezone=timezone)
-        return self.organization_preferences_update(preferences)
+        return self.update_preferences(preferences)
 
-    def organization_preferences_get(self):
+    def get_preferences(self):
         """
         Retrieve preferences of current organization.
 
@@ -208,7 +208,7 @@ class Organizations(Base):
         r = self.client.GET(update_preference)
         return r
 
-    def organization_preferences_update(self, preferences: PersonalPreferences):
+    def update_preferences(self, preferences: PersonalPreferences):
         """
         Update preferences of current organization as a whole.
 
@@ -216,7 +216,7 @@ class Organizations(Base):
         However, Grafana will reset all undefined attributes to its internal defaults.
 
         If you want to update specific preference attributes, without touching the others,
-        please use the `organization_preferences_patch` method.
+        please use the `patch_preferences` method.
 
         :param preferences:
         :return:
@@ -230,7 +230,7 @@ class Organizations(Base):
         )
         return r
 
-    def organization_preferences_patch(self, preferences: PersonalPreferences):
+    def patch_preferences(self, preferences: PersonalPreferences):
         """
         Update specific preferences of current organization.
 

--- a/grafana_client/elements/organization.py
+++ b/grafana_client/elements/organization.py
@@ -1,6 +1,6 @@
 import warnings
 
-from ..model import UserOrganizationPreferences
+from ..model import PersonalPreferences
 from .base import Base
 
 
@@ -195,7 +195,7 @@ class Organizations(Base):
         :return:
         """
         warnings.warn("Deprecated, please use `organization_preferences_update`", DeprecationWarning)
-        preferences = UserOrganizationPreferences(theme=theme, homeDashboardId=home_dashboard_id, timezone=timezone)
+        preferences = PersonalPreferences(theme=theme, homeDashboardId=home_dashboard_id, timezone=timezone)
         return self.organization_preferences_update(preferences)
 
     def organization_preferences_get(self):
@@ -208,7 +208,7 @@ class Organizations(Base):
         r = self.client.GET(update_preference)
         return r
 
-    def organization_preferences_update(self, preferences: UserOrganizationPreferences):
+    def organization_preferences_update(self, preferences: PersonalPreferences):
         """
         Update preferences of current organization as a whole.
 
@@ -230,7 +230,7 @@ class Organizations(Base):
         )
         return r
 
-    def organization_preferences_patch(self, preferences: UserOrganizationPreferences):
+    def organization_preferences_patch(self, preferences: PersonalPreferences):
         """
         Update specific preferences of current organization.
 

--- a/grafana_client/elements/organization.py
+++ b/grafana_client/elements/organization.py
@@ -88,12 +88,63 @@ class Organization(Base):
         r = self.client.DELETE(delete_user_current_organization_path)
         return r
 
+    def get_preferences(self):
+        """
+        Retrieve preferences of current organization.
+
+        :return:
+        """
+        update_preference = "/org/preferences"
+        r = self.client.GET(update_preference)
+        return r
+
+    def update_preferences(self, preferences: PersonalPreferences):
+        """
+        Update preferences of current organization as a whole.
+
+        From the `preferences` instance, only attributes with values `not None` will be submitted.
+        However, Grafana will reset all undefined attributes to its internal defaults.
+
+        If you want to update specific preference attributes, without touching the others,
+        please use the `patch_preferences` method.
+
+        :param preferences:
+        :return:
+        """
+        update_preference = "/org/preferences"
+        data = preferences.asdict(filter_none=True)
+
+        r = self.client.PUT(
+            update_preference,
+            json=data,
+        )
+        return r
+
+    def patch_preferences(self, preferences: PersonalPreferences):
+        """
+        Update specific preferences of current organization.
+
+        From the `preferences` instance, only attributes with values `not None` will be submitted
+        and updated.
+
+        :param preferences:
+        :return:
+        """
+        update_preference = "/org/preferences"
+        data = preferences.asdict(filter_none=True)
+
+        r = self.client.PATCH(
+            update_preference,
+            json=data,
+        )
+        return r
+
 
 class Organizations(Base):
-    def __init__(self, client):
+    def __init__(self, client, api):
         super(Organizations, self).__init__(client)
         self.client = client
-        self.path = "/users"
+        self.api = api
 
     def update_organization(self, organization_id, organization):
         """
@@ -183,8 +234,8 @@ class Organizations(Base):
         """
         :return:
         """
-        warnings.warn("This method is deprecated, please use `get_preferences`", DeprecationWarning)
-        return self.get_preferences()
+        warnings.warn("This method is deprecated, please use `organization.get_preferences`", DeprecationWarning)
+        return self.api.organization.get_preferences()
 
     def organization_preference_update(self, theme="", home_dashboard_id=0, timezone="utc"):
         """
@@ -194,57 +245,6 @@ class Organizations(Base):
         :param timezone:
         :return:
         """
-        warnings.warn("This method is deprecated, please use `update_preferences`", DeprecationWarning)
+        warnings.warn("This method is deprecated, please use `organization.update_preferences`", DeprecationWarning)
         preferences = PersonalPreferences(theme=theme, homeDashboardId=home_dashboard_id, timezone=timezone)
-        return self.update_preferences(preferences)
-
-    def get_preferences(self):
-        """
-        Retrieve preferences of current organization.
-
-        :return:
-        """
-        update_preference = "/org/preferences"
-        r = self.client.GET(update_preference)
-        return r
-
-    def update_preferences(self, preferences: PersonalPreferences):
-        """
-        Update preferences of current organization as a whole.
-
-        From the `preferences` instance, only attributes with values `not None` will be submitted.
-        However, Grafana will reset all undefined attributes to its internal defaults.
-
-        If you want to update specific preference attributes, without touching the others,
-        please use the `patch_preferences` method.
-
-        :param preferences:
-        :return:
-        """
-        update_preference = "/org/preferences"
-        data = preferences.asdict(filter_none=True)
-
-        r = self.client.PUT(
-            update_preference,
-            json=data,
-        )
-        return r
-
-    def patch_preferences(self, preferences: PersonalPreferences):
-        """
-        Update specific preferences of current organization.
-
-        From the `preferences` instance, only attributes with values `not None` will be submitted
-        and updated.
-
-        :param preferences:
-        :return:
-        """
-        update_preference = "/org/preferences"
-        data = preferences.asdict(filter_none=True)
-
-        r = self.client.PATCH(
-            update_preference,
-            json=data,
-        )
-        return r
+        return self.api.organization.update_preferences(preferences)

--- a/grafana_client/elements/team.py
+++ b/grafana_client/elements/team.py
@@ -1,4 +1,5 @@
 import typing as t
+import warnings
 
 from ..model import PersonalPreferences
 from .base import Base
@@ -135,7 +136,27 @@ class Teams(Base):
         r = self.client.DELETE(remove_team_member_path)
         return r
 
-    def get_team_preferences(self, team_id):
+    def get_team_preferences(self, team_id: int):
+        """
+
+        :param team_id:
+        :return:
+        """
+        warnings.warn("This method is deprecated, please use `get_preferences`", DeprecationWarning)
+        return self.get_preferences(team_id=team_id)
+
+    def update_team_preferences(self, team_id: int, preferences: t.Dict):
+        """
+
+        :param team_id:
+        :param preferences:
+        :return:
+        """
+        warnings.warn("This method is deprecated, please use `update_preferences`", DeprecationWarning)
+        preferences = PersonalPreferences(**preferences)
+        return self.update_preferences(team_id=team_id, preferences=preferences)
+
+    def get_preferences(self, team_id: int):
         """
 
         :param team_id:
@@ -145,7 +166,7 @@ class Teams(Base):
         r = self.client.GET(get_team_preferences_path)
         return r
 
-    def update_team_preferences(self, team_id, preferences: t.Union[PersonalPreferences, t.Dict]):
+    def update_preferences(self, team_id: int, preferences: PersonalPreferences):
         """
 
         :param team_id:
@@ -153,14 +174,12 @@ class Teams(Base):
         :return:
         """
         update_team_preferences_path = "/teams/%s/preferences" % team_id
-        if isinstance(preferences, dict):
-            data = preferences
-        elif isinstance(preferences, PersonalPreferences):
+        if isinstance(preferences, PersonalPreferences):
             data = preferences.asdict(filter_none=True)
         else:
             raise TypeError(
                 f"Unable to use data type '{type(preferences)}' for updating preferences. "
-                f"Use `PersonalPreferences` or `dict`."
+                f"Please use `PersonalPreferences` instead."
             )
         r = self.client.PUT(update_team_preferences_path, json=data)
         return r

--- a/grafana_client/elements/team.py
+++ b/grafana_client/elements/team.py
@@ -1,3 +1,6 @@
+import typing as t
+
+from ..model import PersonalPreferences
 from .base import Base
 
 
@@ -142,7 +145,7 @@ class Teams(Base):
         r = self.client.GET(get_team_preferences_path)
         return r
 
-    def update_team_preferences(self, team_id, preferences):
+    def update_team_preferences(self, team_id, preferences: t.Union[PersonalPreferences, t.Dict]):
         """
 
         :param team_id:
@@ -150,7 +153,16 @@ class Teams(Base):
         :return:
         """
         update_team_preferences_path = "/teams/%s/preferences" % team_id
-        r = self.client.PUT(update_team_preferences_path, json=preferences)
+        if isinstance(preferences, dict):
+            data = preferences
+        elif isinstance(preferences, PersonalPreferences):
+            data = preferences.asdict(filter_none=True)
+        else:
+            raise TypeError(
+                f"Unable to use data type '{type(preferences)}' for updating preferences. "
+                f"Use `PersonalPreferences` or `dict`."
+            )
+        r = self.client.PUT(update_team_preferences_path, json=data)
         return r
 
     def get_team_external_group(self, team_id):

--- a/grafana_client/elements/user.py
+++ b/grafana_client/elements/user.py
@@ -1,3 +1,4 @@
+from ..model import PersonalPreferences
 from .base import Base
 
 
@@ -171,4 +172,55 @@ class User(Base):
         """
         unstar_dashboard = "/user/stars/dashboard/%s" % dashboard_id
         r = self.client.DELETE(unstar_dashboard)
+        return r
+
+    def get_preferences(self):
+        """
+        Retrieve preferences of current user.
+
+        :return:
+        """
+        update_preference = "/user/preferences"
+        r = self.client.GET(update_preference)
+        return r
+
+    def update_preferences(self, preferences: PersonalPreferences):
+        """
+        Update preferences of current user as a whole.
+
+        From the `preferences` instance, only attributes with values `not None` will be submitted.
+        However, Grafana will reset all undefined attributes to its internal defaults.
+
+        If you want to update specific preference attributes, without touching the others,
+        please use the `patch_preferences` method.
+
+        :param preferences:
+        :return:
+        """
+        update_preference = "/user/preferences"
+        data = preferences.asdict(filter_none=True)
+
+        r = self.client.PUT(
+            update_preference,
+            json=data,
+        )
+        return r
+
+    def patch_preferences(self, preferences: PersonalPreferences):
+        """
+        Update specific preferences of current user.
+
+        From the `preferences` instance, only attributes with values `not None` will be submitted
+        and updated.
+
+        :param preferences:
+        :return:
+        """
+        update_preference = "/user/preferences"
+        data = preferences.asdict(filter_none=True)
+
+        r = self.client.PATCH(
+            update_preference,
+            json=data,
+        )
         return r

--- a/grafana_client/model.py
+++ b/grafana_client/model.py
@@ -70,9 +70,9 @@ class DatasourceHealthResponse:
 
 
 @dataclasses.dataclass
-class UserOrganizationPreferences:
+class PersonalPreferences:
     """
-    Request/response model for user- and organization-preferences.
+    Request/response model for user-, team- and organization-preferences.
 
     https://grafana.com/docs/grafana/latest/developers/http_api/preferences/
     """

--- a/grafana_client/model.py
+++ b/grafana_client/model.py
@@ -67,3 +67,32 @@ class DatasourceHealthResponse:
         data = self.asdict()
         del data["response"]
         return data
+
+
+@dataclasses.dataclass
+class UserOrganizationPreferences:
+    """
+    Request/response model for user- and organization-preferences.
+
+    https://grafana.com/docs/grafana/latest/developers/http_api/preferences/
+    """
+
+    homeDashboardId: Optional[int] = None
+    homeDashboardUID: Optional[str] = None
+    locale: Optional[str] = None
+    theme: Optional[str] = None
+    timezone: Optional[str] = None
+    weekStart: Optional[str] = None
+
+    def asdict(self, filter_none=False):
+        if filter_none:
+            return dataclasses.asdict(self, dict_factory=self.dict_factory_filter_none)
+        else:
+            return dataclasses.asdict(self)
+
+    @staticmethod
+    def dict_factory_filter_none(seq=None, **kwargs):
+        seq = [item for item in seq if item[1] is not None]
+        data = dict(seq)
+        data.update(kwargs)
+        return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ line-length = 120
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+skip_glob = [".*_cache"]
 
 [tool.coverage.run]
 source = ["grafana_client"]

--- a/test/elements/test_organization.py
+++ b/test/elements/test_organization.py
@@ -35,13 +35,13 @@ class OrganizationTestCase(unittest.TestCase):
     def test_get_preferences(self, m):
         m.get("http://localhost/api/org/preferences", json={"theme": "", "homeDashboardId": 0, "timezone": ""})
 
-        result = self.grafana.organizations.get_preferences()
+        result = self.grafana.organization.get_preferences()
         self.assertEqual(result["homeDashboardId"], 0)
 
     @requests_mock.Mocker()
     def test_update_preferences(self, m):
         m.put("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
-        preference = self.grafana.organizations.update_preferences(
+        preference = self.grafana.organization.update_preferences(
             PersonalPreferences(theme="", homeDashboardId=999, timezone="utc")
         )
         self.assertEqual(preference["message"], "Preferences updated")
@@ -49,7 +49,7 @@ class OrganizationTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_patch_preferences(self, m):
         m.patch("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
-        preference = self.grafana.organizations.patch_preferences(PersonalPreferences(homeDashboardUID="zgjG8dKVz"))
+        preference = self.grafana.organization.patch_preferences(PersonalPreferences(homeDashboardUID="zgjG8dKVz"))
         self.assertEqual(preference["message"], "Preferences updated")
 
     @requests_mock.Mocker()

--- a/test/elements/test_organization.py
+++ b/test/elements/test_organization.py
@@ -3,7 +3,7 @@ import unittest
 import requests_mock
 
 from grafana_client import GrafanaApi
-from grafana_client.model import UserOrganizationPreferences
+from grafana_client.model import PersonalPreferences
 
 
 class OrganizationTestCase(unittest.TestCase):
@@ -42,7 +42,7 @@ class OrganizationTestCase(unittest.TestCase):
     def test_organization_preferences_update(self, m):
         m.put("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
         preference = self.grafana.organizations.organization_preferences_update(
-            UserOrganizationPreferences(theme="", homeDashboardId=999, timezone="utc")
+            PersonalPreferences(theme="", homeDashboardId=999, timezone="utc")
         )
         self.assertEqual(preference["message"], "Preferences updated")
 
@@ -50,7 +50,7 @@ class OrganizationTestCase(unittest.TestCase):
     def test_organization_preferences_patch(self, m):
         m.patch("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
         preference = self.grafana.organizations.organization_preferences_patch(
-            UserOrganizationPreferences(homeDashboardUID="zgjG8dKVz")
+            PersonalPreferences(homeDashboardUID="zgjG8dKVz")
         )
         self.assertEqual(preference["message"], "Preferences updated")
 

--- a/test/elements/test_organization.py
+++ b/test/elements/test_organization.py
@@ -3,6 +3,7 @@ import unittest
 import requests_mock
 
 from grafana_client import GrafanaApi
+from grafana_client.model import UserOrganizationPreferences
 
 
 class OrganizationTestCase(unittest.TestCase):
@@ -27,6 +28,29 @@ class OrganizationTestCase(unittest.TestCase):
         m.put("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
         preference = self.grafana.organizations.organization_preference_update(
             theme="", home_dashboard_id=0, timezone="utc"
+        )
+        self.assertEqual(preference["message"], "Preferences updated")
+
+    @requests_mock.Mocker()
+    def test_organization_preferences_get(self, m):
+        m.get("http://localhost/api/org/preferences", json={"theme": "", "homeDashboardId": 0, "timezone": ""})
+
+        result = self.grafana.organizations.organization_preferences_get()
+        self.assertEqual(result["homeDashboardId"], 0)
+
+    @requests_mock.Mocker()
+    def test_organization_preferences_update(self, m):
+        m.put("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
+        preference = self.grafana.organizations.organization_preferences_update(
+            UserOrganizationPreferences(theme="", homeDashboardId=999, timezone="utc")
+        )
+        self.assertEqual(preference["message"], "Preferences updated")
+
+    @requests_mock.Mocker()
+    def test_organization_preferences_patch(self, m):
+        m.patch("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
+        preference = self.grafana.organizations.organization_preferences_patch(
+            UserOrganizationPreferences(homeDashboardUID="zgjG8dKVz")
         )
         self.assertEqual(preference["message"], "Preferences updated")
 

--- a/test/elements/test_organization.py
+++ b/test/elements/test_organization.py
@@ -32,26 +32,24 @@ class OrganizationTestCase(unittest.TestCase):
         self.assertEqual(preference["message"], "Preferences updated")
 
     @requests_mock.Mocker()
-    def test_organization_preferences_get(self, m):
+    def test_get_preferences(self, m):
         m.get("http://localhost/api/org/preferences", json={"theme": "", "homeDashboardId": 0, "timezone": ""})
 
-        result = self.grafana.organizations.organization_preferences_get()
+        result = self.grafana.organizations.get_preferences()
         self.assertEqual(result["homeDashboardId"], 0)
 
     @requests_mock.Mocker()
-    def test_organization_preferences_update(self, m):
+    def test_update_preferences(self, m):
         m.put("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
-        preference = self.grafana.organizations.organization_preferences_update(
+        preference = self.grafana.organizations.update_preferences(
             PersonalPreferences(theme="", homeDashboardId=999, timezone="utc")
         )
         self.assertEqual(preference["message"], "Preferences updated")
 
     @requests_mock.Mocker()
-    def test_organization_preferences_patch(self, m):
+    def test_patch_preferences(self, m):
         m.patch("http://localhost/api/org/preferences", json={"message": "Preferences updated"})
-        preference = self.grafana.organizations.organization_preferences_patch(
-            PersonalPreferences(homeDashboardUID="zgjG8dKVz")
-        )
+        preference = self.grafana.organizations.patch_preferences(PersonalPreferences(homeDashboardUID="zgjG8dKVz"))
         self.assertEqual(preference["message"], "Preferences updated")
 
     @requests_mock.Mocker()

--- a/test/elements/test_team.py
+++ b/test/elements/test_team.py
@@ -244,6 +244,9 @@ class TeamsTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_get_team_preferences(self, m):
+        """
+        Legacy method.
+        """
         m.get(
             "http://localhost/api/teams/1/preferences",
             json={"theme": "", "homeDashboardId": 0, "timezone": ""},
@@ -252,7 +255,10 @@ class TeamsTestCase(unittest.TestCase):
         self.assertEqual(prefs["homeDashboardId"], 0)
 
     @requests_mock.Mocker()
-    def test_update_team_preferences_dict(self, m):
+    def test_update_team_preferences(self, m):
+        """
+        Legacy method, using a dictionary.
+        """
         m.put(
             "http://localhost/api/teams/1/preferences",
             json={"message": "Preferences updated"},
@@ -266,14 +272,29 @@ class TeamsTestCase(unittest.TestCase):
         self.assertEqual(updates["message"], "Preferences updated")
 
     @requests_mock.Mocker()
-    def test_update_team_preferences_model(self, m):
+    def test_get_preferences(self, m):
+        """
+        Modern method.
+        """
+        m.get(
+            "http://localhost/api/teams/1/preferences",
+            json={"theme": "", "homeDashboardId": 0, "timezone": ""},
+        )
+        prefs = self.grafana.teams.get_preferences("1")
+        self.assertEqual(prefs["homeDashboardId"], 0)
+
+    @requests_mock.Mocker()
+    def test_update_preferences(self, m):
+        """
+        Modern method, using a `PersonalPreferences` instance.
+        """
         m.put(
             "http://localhost/api/teams/1/preferences",
             json={"message": "Preferences updated"},
         )
         prefs = PersonalPreferences(theme="light", homeDashboardId=0, timezone="utc")
 
-        updates = self.grafana.teams.update_team_preferences("1", prefs)
+        updates = self.grafana.teams.update_preferences("1", prefs)
         history = m.request_history
         json_payload = history[0].json()
         self.assertEqual(json_payload["theme"], "light")

--- a/test/elements/test_team.py
+++ b/test/elements/test_team.py
@@ -4,6 +4,7 @@ import unittest
 import requests_mock
 
 from grafana_client import GrafanaApi
+from grafana_client.model import PersonalPreferences
 
 
 class TeamsTestCase(unittest.TestCase):
@@ -251,12 +252,26 @@ class TeamsTestCase(unittest.TestCase):
         self.assertEqual(prefs["homeDashboardId"], 0)
 
     @requests_mock.Mocker()
-    def test_update_team_preferences(self, m):
+    def test_update_team_preferences_dict(self, m):
         m.put(
             "http://localhost/api/teams/1/preferences",
             json={"message": "Preferences updated"},
         )
-        prefs = {"theme": "light", "homeDashboardId": 0, "timezone": ""}
+        prefs = {"theme": "light", "homeDashboardId": 0, "timezone": "utc"}
+
+        updates = self.grafana.teams.update_team_preferences("1", prefs)
+        history = m.request_history
+        json_payload = history[0].json()
+        self.assertEqual(json_payload["theme"], "light")
+        self.assertEqual(updates["message"], "Preferences updated")
+
+    @requests_mock.Mocker()
+    def test_update_team_preferences_model(self, m):
+        m.put(
+            "http://localhost/api/teams/1/preferences",
+            json={"message": "Preferences updated"},
+        )
+        prefs = PersonalPreferences(theme="light", homeDashboardId=0, timezone="utc")
 
         updates = self.grafana.teams.update_team_preferences("1", prefs)
         history = m.request_history

--- a/test/elements/test_user.py
+++ b/test/elements/test_user.py
@@ -3,6 +3,7 @@ import unittest
 import requests_mock
 
 from grafana_client import GrafanaApi
+from grafana_client.model import PersonalPreferences
 
 
 class UsersTestCase(unittest.TestCase):
@@ -169,3 +170,24 @@ class UserTestCase(unittest.TestCase):
         )
         result = self.grafana.user.unstar_actual_user_dashboard("987vb7t33")
         self.assertEqual(result, {})
+
+    @requests_mock.Mocker()
+    def test_get_preferences(self, m):
+        m.get("http://localhost/api/user/preferences", json={"theme": "", "homeDashboardId": 0, "timezone": ""})
+
+        result = self.grafana.user.get_preferences()
+        self.assertEqual(result["homeDashboardId"], 0)
+
+    @requests_mock.Mocker()
+    def test_update_preferences(self, m):
+        m.put("http://localhost/api/user/preferences", json={"message": "Preferences updated"})
+        preference = self.grafana.user.update_preferences(
+            PersonalPreferences(theme="", homeDashboardId=999, timezone="utc")
+        )
+        self.assertEqual(preference["message"], "Preferences updated")
+
+    @requests_mock.Mocker()
+    def test_patch_preferences(self, m):
+        m.patch("http://localhost/api/user/preferences", json={"message": "Preferences updated"})
+        preference = self.grafana.user.patch_preferences(PersonalPreferences(homeDashboardUID="zgjG8dKVz"))
+        self.assertEqual(preference["message"], "Preferences updated")


### PR DESCRIPTION
Hi there,

this patch is related to #42 by @autokilla47. Because all preferences [^1][^2] are apparently using the same data model, this is reflected by a dataclass `PersonalPreferences` now.

The new methods are:

- `user.{get,update,patch}_preferences`
- `organization.{get,update,patch}_preferences`
- `team.{get,update}_preferences`

An example how to update a single preference attribute:
```python
from grafana_client import GrafanaApi
from grafana_client.model import PersonalPreferences

grafana = GrafanaApi.from_url("http://admin:admin@localhost:3000")
preferences = PersonalPreferences(homeDashboardUID="zgjG8dKVz")
grafana.organization.patch_preferences(preferences)
```

With kind regards,
Andreas.

[^1]: https://grafana.com/docs/grafana/latest/developers/http_api/preferences/ ff.
[^2]: https://grafana.com/docs/grafana/latest/developers/http_api/team/#get-team-preferences ff.
