### PR TITLE
Alerting Provisioning: Add support for `X-Disable-Provenance` header

### DIFF
--- a/grafana_client/elements/alertingprovisioning.py
+++ b/grafana_client/elements/alertingprovisioning.py
@@ -16,25 +16,31 @@ class AlertingProvisioning(Base):
         r = self.client.GET(get_alertrule_path)
         return r
 
-    def create_alertrule(self, alertrule):
+    def create_alertrule(self, alertrule, disable_provenance=False):
         """
         :param alertrule:
+        :param disable_provenance:
         :return:
         """
-
         create_alertrule_path = "/v1/provisioning/alert-rules"
-        r = self.client.POST(create_alertrule_path, json=alertrule)
+        headers = {}
+        if disable_provenance:
+            headers["X-Disable-Provenance"] = "true"
+        r = self.client.POST(create_alertrule_path, json=alertrule, headers=headers)
         return r
 
-    def update_alertrule(self, alertrule_uid, alertrule):
+    def update_alertrule(self, alertrule_uid, alertrule, disable_provenance=False):
         """
-        @param alertrule_uid:
-        @param alertrule:
-        @return:
+        :param alertrule_uid:
+        :param alertrule:
+        :param disable_provenance:
+        :return:
         """
-
         update_alertrule_path = "/v1/provisioning/alert-rules/%s" % alertrule_uid
-        r = self.client.PUT(update_alertrule_path, json=alertrule)
+        headers = {}
+        if disable_provenance:
+            headers["X-Disable-Provenance"] = "true"
+        r = self.client.PUT(update_alertrule_path, json=alertrule, headers=headers)
         return r
 
     def update_rule_group_interval(self, folder_uid, group_uid, alertrule_group):

--- a/test/elements/test_alertingprovisioning.py
+++ b/test/elements/test_alertingprovisioning.py
@@ -38,7 +38,7 @@ class AlertingProvisioningTestCase(unittest.TestCase):
         self.assertEqual(response["uid"], "bUUGqLiVk")
 
     @requests_mock.Mocker()
-    def test_create_alertrule(self, m):
+    def test_create_alertrule_default(self, m):
         m.post(
             "http://localhost/api/v1/provisioning/alert-rules",
             json=ALERTRULE,
@@ -47,8 +47,29 @@ class AlertingProvisioningTestCase(unittest.TestCase):
         response = self.grafana.alertingprovisioning.create_alertrule(ALERTRULE)
         self.assertEqual(response["uid"], "bUUGqLiVk")
 
+        # Verify request header.
+        history = m.request_history
+        headers = history[0].headers
+        self.assertNotIn("X-Disable-Provenance", headers)
+
     @requests_mock.Mocker()
-    def test_update_alertrule(self, m):
+    def test_create_alertrule_disable_provenance(self, m):
+        m.post(
+            "http://localhost/api/v1/provisioning/alert-rules",
+            json=ALERTRULE,
+        )
+
+        response = self.grafana.alertingprovisioning.create_alertrule(ALERTRULE, disable_provenance=True)
+        self.assertEqual(response["uid"], "bUUGqLiVk")
+
+        # Verify request header.
+        history = m.request_history
+        headers = history[0].headers
+        self.assertIn("X-Disable-Provenance", headers)
+        self.assertEqual(headers["X-Disable-Provenance"], "true")
+
+    @requests_mock.Mocker()
+    def test_update_alertrule_default(self, m):
         m.put(
             "http://localhost/api/v1/provisioning/alert-rules/bUUGqLiVk",
             json=ALERTRULE,
@@ -56,3 +77,26 @@ class AlertingProvisioningTestCase(unittest.TestCase):
 
         response = self.grafana.alertingprovisioning.update_alertrule(alertrule_uid="bUUGqLiVk", alertrule=ALERTRULE)
         self.assertEqual(response["uid"], "bUUGqLiVk")
+
+        # Verify request header.
+        history = m.request_history
+        headers = history[0].headers
+        self.assertNotIn("X-Disable-Provenance", headers)
+
+    @requests_mock.Mocker()
+    def test_update_alertrule_disable_provenance(self, m):
+        m.put(
+            "http://localhost/api/v1/provisioning/alert-rules/bUUGqLiVk",
+            json=ALERTRULE,
+        )
+
+        response = self.grafana.alertingprovisioning.update_alertrule(
+            alertrule_uid="bUUGqLiVk", alertrule=ALERTRULE, disable_provenance=True
+        )
+        self.assertEqual(response["uid"], "bUUGqLiVk")
+
+        # Verify request header.
+        history = m.request_history
+        headers = history[0].headers
+        self.assertIn("X-Disable-Provenance", headers)
+        self.assertEqual(headers["X-Disable-Provenance"], "true")


### PR DESCRIPTION
Hi there,

this patch implements the suggestion by @jyepesr1 from #52.

@alexmobo of Grafana Labs says at https://github.com/grafana/grafana/pull/58410:

> To be able to modify alerts created via API within the UI later, we are enabling a workaround within the Alerting Provisioning API. Just add the `x-disable-provenance` header to the following requests:
>
> - `POST /api/v1/provisioning/alert-rules`
> - `PUT /api/v1/provisioning/alert-rules/{UID}`

Thank you!

With kind regards,
Andreas.

/cc @bursztym, @bursztyn-pl
