### PR TITLE
CI: Use ubuntu-20.04 to re-add support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: ["ubuntu-20.04"]
         python-version: [
           '3.6', '3.7', '3.8', '3.9', '3.10', '3.11',
           'pypy-3.6', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9',

--- a/grafana_client/model.py
+++ b/grafana_client/model.py
@@ -19,6 +19,9 @@ class DatasourceModel:
     """
     Represent the minimum required fields to create a JSON payload suitable for
     submitting to the Grafana HTTP API.
+
+    TODO: Field `database` will be deprecated.
+          https://github.com/grafana/grafana/issues/59115
     """
 
     name: str


### PR DESCRIPTION
What the title says.