### PR TITLE
Add support for a subset of "RBAC" API

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ versions of Grafana might not support certain features or subsystems.
 | Organisation | + |
 | Other | + |
 | Preferences | + |
+| Rbac | +- |
 | Snapshot | + |
 | Teams | + |
 | User | + |

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -23,6 +23,7 @@ from .elements import (
     Notifications,
     Organization,
     Organizations,
+    Rbac,
     Search,
     Snapshots,
     Teams,
@@ -70,6 +71,7 @@ class GrafanaApi:
         self.search = Search(self.client)
         self.user = User(self.client)
         self.users = Users(self.client)
+        self.rbac = Rbac(self.client)
         self.teams = Teams(self.client)
         self.annotations = Annotations(self.client)
         self.snapshots = Snapshots(self.client)

--- a/grafana_client/elements/__init__.py
+++ b/grafana_client/elements/__init__.py
@@ -10,6 +10,7 @@ from .folder import Folder
 from .health import Health
 from .notifications import Notifications
 from .organization import Organization, Organizations
+from .rbac import Rbac
 from .search import Search
 from .snapshots import Snapshots
 from .team import Teams

--- a/grafana_client/elements/rbac.py
+++ b/grafana_client/elements/rbac.py
@@ -1,0 +1,53 @@
+from .base import Base
+
+
+class Rbac(Base):
+    def __init__(self, client):
+        super(Rbac, self).__init__(client)
+        self.client = client
+
+    def get_rbac_roles_all(self):
+        """
+        The Rbac is only available in Grafana Enterprise.
+
+        :return:
+        """
+        roles_path = "/access-control/roles"
+        r = self.client.GET(roles_path)
+        return r
+
+    def add_rbac_role_team(self, team_id, role_uid):
+        """
+        The Rbac is only available in Grafana Enterprise.
+
+        :param team_id:
+        :param role_uid:
+        :return:
+        """
+        role_team_path = "/access-control/teams/%s/roles" % team_id
+        r = self.client.POST(role_team_path, json={"roleUid": role_uid})
+        return r
+
+    def add_rbac_roles_team(self, team_id, role_uids):
+        """
+        The Rbac is only available in Grafana Enterprise.
+
+        :param team_id:
+        :param role_uids:
+        :return:
+        """
+        role_team_path = "/access-control/teams/%s/roles" % team_id
+        r = self.client.PUT(role_team_path, json={"roleUids": role_uids})
+        return r
+
+    def remove_rbac_role_team(self, team_id, role_uid):
+        """
+        The Rbac is only available in Grafana Enterprise.
+
+        :param team_id:
+        :param role_uid:
+        :return:
+        """
+        role_team_path = "/access-control/teams/%s/roles/%s" % (team_id, role_uid)
+        r = self.client.DELETE(role_team_path)
+        return r

--- a/test/elements/test_rbac.py
+++ b/test/elements/test_rbac.py
@@ -1,0 +1,64 @@
+import unittest
+
+import requests_mock
+
+from grafana_client import GrafanaApi
+
+
+class RbacTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+    @requests_mock.Mocker()
+    def test_get_rbac_roles_all(self, m):
+        m.get(
+            "http://localhost/api/access-control/roles",
+            json=[
+                {
+                    "version": 5,
+                    "uid": "vi9mlLjGz",
+                    "name": "fixed:datasources.permissions:writer",
+                    "description": "Create, read or delete data source permissions.",
+                    "global": True,
+                    "updated": "2021-05-13T22:41:49+02:00",
+                    "created": "2021-05-13T16:24:26+02:00",
+                }
+            ],
+        )
+        roles = self.grafana.rbac.get_rbac_roles_all()
+        self.assertEqual(roles[0]["name"], "fixed:datasources.permissions:writer")
+        self.assertEqual(len(roles), 1)
+
+    @requests_mock.Mocker()
+    def test_add_rbac_role_teams(self, m):
+        m.post(
+            "http://localhost/api/access-control/teams/1/roles",
+            json={"message": "Role added to the team."},
+        )
+        history = m.request_history
+
+        r = self.grafana.rbac.add_rbac_role_team("1", "XvHQJq57z")
+        self.assertEqual(history[0].json()["roleUid"], "XvHQJq57z")
+        self.assertEqual(r["message"], "Role added to the team.")
+
+    @requests_mock.Mocker()
+    def test_add_rbac_roles_teams(self, m):
+        m.put(
+            "http://localhost/api/access-control/teams/1/roles",
+            json={"message": "Team roles have been updated."},
+        )
+        history = m.request_history
+
+        roleUids = ["ZiHQJq5nk", "GzNQ1357k"]
+        r = self.grafana.rbac.add_rbac_roles_team("1", roleUids)
+        self.assertEqual(history[0].json()["roleUids"], roleUids)
+        self.assertEqual(r["message"], "Team roles have been updated.")
+
+    @requests_mock.Mocker()
+    def test_remove_rbac_role_team(self, m):
+        m.delete(
+            "http://localhost/api/access-control/teams/1/roles/AFUXBHKnk",
+            json={"message": "Role removed from team."},
+        )
+        r = self.grafana.rbac.remove_rbac_role_team("1", "AFUXBHKnk")
+        self.assertEqual(r["message"], "Role removed from team.")


### PR DESCRIPTION
## Description
Add support for a subset of "RBAC" API :

- GET /api/access-control/roles
- PUT /api/access-control/teams/:teamId/roles
- POST /api/access-control/teams/:teamId/roles
- DELETE /api/access-control/teams/:teams/roles/:roleUID


## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
