### PR TITLE
CI: Fix `release` workflow, which creates a release on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
     - name: version
       id: version
       run: |
-        echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     - name: install
       run: |
-        go get github.com/github-release/github-release
+        go install github.com/github-release/github-release@100e8554
     - name: release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- GHA: Deprecation of save-state and set-output commands
  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- Golang: Deprecation of 'go get' for installing executables
  https://go.dev/doc/go-get-install-deprecation
