### PR TITLE
Add missing argument `dashboard_uid` to `get_annotation` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Add missing argument `dashboard_uid` to `get_annotation` method.
+  Thanks, @nikita-b.
+
 
 ## 3.5.0 (2022-12-07)
 

--- a/grafana_client/elements/annotations.py
+++ b/grafana_client/elements/annotations.py
@@ -12,6 +12,7 @@ class Annotations(Base):
         time_to=None,
         alert_id=None,
         dashboard_id=None,
+        dashboard_uid=None,
         panel_id=None,
         user_id=None,
         ann_type=None,
@@ -25,6 +26,7 @@ class Annotations(Base):
         :param time_to:
         :param alert_id:
         :param dashboard_id:
+        :param dashboard_uid:
         :param panel_id:
         :param user_id:
         :param ann_type: Annotation type. On of alert|annotation
@@ -46,6 +48,9 @@ class Annotations(Base):
 
         if dashboard_id:
             params.append("dashboardId=%s" % dashboard_id)
+
+        if dashboard_uid:
+            params.append("dashboardUID=%s" % dashboard_uid)
 
         if panel_id:
             params.append("panelId=%s" % panel_id)

--- a/test/elements/test_annotations.py
+++ b/test/elements/test_annotations.py
@@ -19,13 +19,14 @@ class AnnotationsTestCase(unittest.TestCase):
     def test_annotations(self, m):
         m.get(
             "http://localhost/api/annotations?from=1563183710618&to=1563185212275"
-            "&alertId=11&dashboardId=111&panelId=22&userId=42&type=alert&tags=tags-test&limit=1",
+            "&alertId=11&dashboardId=111&dashboardUID=v1Mm5FPVz&panelId=22&userId=42&type=alert&tags=tags-test&limit=1",
             json=[
                 {
                     "id": 80,
                     "alertId": 11,
                     "alertName": "",
                     "dashboardId": 111,
+                    "dashboardUID": "v1Mm5FPVz",
                     "panelId": 22,
                     "userId": 42,
                     "type": "alert",
@@ -48,6 +49,7 @@ class AnnotationsTestCase(unittest.TestCase):
             time_to=1563185212275,
             alert_id=11,
             dashboard_id=111,
+            dashboard_uid="v1Mm5FPVz",
             panel_id=22,
             user_id=42,
             ann_type="alert",
@@ -56,6 +58,7 @@ class AnnotationsTestCase(unittest.TestCase):
         )
         self.assertEqual(annotations[0]["text"], "Annotation Description")
         self.assertEqual(annotations[0]["alertId"], 11)
+        self.assertEqual(annotations[0]["dashboardUID"], "v1Mm5FPVz")
         self.assertEqual(annotations[0]["dashboardId"], 111)
         self.assertEqual(annotations[0]["panelId"], 22)
         self.assertEqual(annotations[0]["userId"], 42)


### PR DESCRIPTION
## Description
I added missing arguments for `/annotaions` endpoint


## Checklist

- [X] The patch has appropriate test coverage
- [X] The patch follows the style guidelines of this project
- [X] The patch has appropriate comments, particularly in hard-to-understand areas
- [X] The documentation was updated corresponding to the patch
- [X] I have performed a self-review of this patch
