### PR TITLE
Add get_rule_group method

### DIFF
--- a/grafana_client/elements/alertingprovisioning.py
+++ b/grafana_client/elements/alertingprovisioning.py
@@ -62,7 +62,7 @@ class AlertingProvisioning(Base):
         r = self.client.GET(get_rule_group_path)
         return r
 
-    def update_rule_group(self, folder_uid, group_uid, alertrule_group, disable_provenance=True):
+    def update_rule_group(self, folder_uid, group_uid, alertrule_group):
         """
         :param folder_uid:
         :param group_uid:

--- a/grafana_client/elements/alertingprovisioning.py
+++ b/grafana_client/elements/alertingprovisioning.py
@@ -52,15 +52,35 @@ class AlertingProvisioning(Base):
         r = self.client.PUT(update_alertrule_path, json=alertrule, headers=headers)
         return r
 
-    def update_rule_group_interval(self, folder_uid, group_uid, alertrule_group):
+    def get_rule_group(self, folder_uid, group_uid):
         """
         :param folder_uid:
         :param group_uid:
         :return:
         """
+        get_rule_group_path = "/v1/provisioning/folder/%s/rule-groups/%s" % (folder_uid, group_uid)
+        r = self.client.GET(get_rule_group_path)
+        return r
+
+    def update_rule_group(self, folder_uid, group_uid, alertrule_group, disable_provenance=True):
+        """
+        :param folder_uid:
+        :param group_uid:
+        :param alertrule_group:
+        :return:
+        """
         update_rule_group_interval_path = "/v1/provisioning/folder/%s/rule-groups/%s" % (folder_uid, group_uid)
         r = self.client.PUT(update_rule_group_interval_path, json=alertrule_group)
         return r
+
+    def update_rule_group_interval(self, folder_uid, group_uid, alertrule_group):
+        """
+        :param folder_uid:
+        :param group_uid:
+        :param alertrule_group:
+        :return:
+        """
+        return self.update_rule_group(folder_uid, group_uid, alertrule_group)
 
     def delete_alertrule(self, alertrule_uid):
         """


### PR DESCRIPTION
## Description
This PR adds a `get_rule_group` method to the AlertProvisioning API, which uses the `/v1/provisioning/folder/%s/rule-groups/%s` endpoint.

It also renames `update_rule_group_interval` to `update_rule_group` for consistency while maintaining the previous method for backward compatibility. I'm happy to revert this change if you'd rather avoid it.

I also attempted to add tests to this. However, I'm unfamiliar with your mocking library and am unsure where to register the  API path, and thus got a `requests_mock.exceptions.NoMockAddress` exception. If this change requires test coverage, I'd be happy to try and add it, but I'd need to be pointed in the right direction.
