### PR TITLE
Deprecate `get_dashboard_by_name` on Grafana 8 and higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Deprecate `get_dashboard_by_name` on Grafana 8 and higher, as it no longer
+  supports getting dashboards by slug. Thanks, @oz123.
+
 
 ## 3.6.0 (2023-07-30)
 

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -61,7 +61,7 @@ class GrafanaApi:
         self.admin = Admin(self.client)
         self.alerting = Alerting(self.client)
         self.alertingprovisioning = AlertingProvisioning(self.client)
-        self.dashboard = Dashboard(self.client)
+        self.dashboard = Dashboard(self.client, self)
         self.dashboard_versions = DashboardVersions(self.client)
         self.datasource = Datasource(self.client, self)
         self.folder = Folder(self.client)

--- a/grafana_client/elements/dashboard.py
+++ b/grafana_client/elements/dashboard.py
@@ -1,10 +1,13 @@
+from distutils.version import LooseVersion
+
 from .base import Base
 
 
 class Dashboard(Base):
-    def __init__(self, client):
+    def __init__(self, client, api):
         super(Dashboard, self).__init__(client)
         self.client = client
+        self.api = api
 
     def get_dashboard(self, dashboard_uid):
         """
@@ -22,6 +25,8 @@ class Dashboard(Base):
         :param dashboard_name:
         :return:
         """
+        if self.api.version and LooseVersion(self.api.version) >= LooseVersion("8"):
+            raise DeprecationWarning("Grafana 8 and higher does not support getting dashboards by slug")
         get_dashboard_path = "/dashboards/db/%s" % dashboard_name
         r = self.client.GET(get_dashboard_path)
         return r

--- a/test/elements/test_dashboard.py
+++ b/test/elements/test_dashboard.py
@@ -34,7 +34,11 @@ class DashboardTestCase(unittest.TestCase):
         self.assertEqual(dashboard["dashboard"]["uid"], "cIBgcSjkk")
 
     @requests_mock.Mocker()
-    def test_get_dashboard_by_name(self, m):
+    def test_get_dashboard_by_name_grafana7(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "6f8c1d9fe4", "database": "ok", "version": "7.5.11"},
+        )
         m.get(
             "http://localhost/api/dashboards/db/Production Overview",
             json={
@@ -56,6 +60,19 @@ class DashboardTestCase(unittest.TestCase):
         )
         dashboard = self.grafana.dashboard.get_dashboard_by_name("Production Overview")
         self.assertEqual(dashboard["dashboard"]["title"], "Production Overview")
+
+    @requests_mock.Mocker()
+    def test_get_dashboard_by_name_grafana8(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "8.0.2"},
+        )
+        with self.assertRaises(DeprecationWarning) as ex:
+            self.grafana.dashboard.get_dashboard_by_name("foobar")
+        self.assertEqual(
+            "Grafana 8 and higher does not support getting dashboards by slug",
+            str(ex.exception),
+        )
 
     @requests_mock.Mocker()
     def test_update_dashboard(self, m):


### PR DESCRIPTION
## About

Grafana 8 no longer supports getting dashboards by slug, as reported by @oz123 at GH-92. Thanks! This patch reflects that, by raising a corresponding exception.

What do you think, @beeradb?
