### PR TITLE
Add API wrapper for "Plugins"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,31 +168,32 @@ versions of Grafana might not support certain features or subsystems.
 
 ### Overview
 
-| API | Status |
-|---|---|
-| Admin | + |
-| Alerting | +- |
+| API                            | Status |
+|--------------------------------|---|
+| Admin                          | + |
+| Alerting                       | +- |
 | Alerting Notification Channels | + |
-| Alerting Provisioning | + |
-| Annotations | + |
-| Authentication | +- |
-| Dashboard | + |
-| Dashboard Versions | + |
-| Dashboard Permissions | + |
-| Data Source | + |
-| Data Source Permissions | + |
-| External Group Sync | + |
-| Folder | + |
-| Folder Permissions | + |
-| Folder/Dashboard Search | +- |
-| Health | + |
-| Organisation | + |
-| Other | + |
-| Preferences | + |
-| Rbac | +- |
-| Snapshot | + |
-| Teams | + |
-| User | + |
+| Alerting Provisioning          | + |
+| Annotations                    | + |
+| Authentication                 | +- |
+| Dashboard                      | + |
+| Dashboard Versions             | + |
+| Dashboard Permissions          | + |
+| Data Source                    | + |
+| Data Source Permissions        | + |
+| External Group Sync            | + |
+| Folder                         | + |
+| Folder Permissions             | + |
+| Folder/Dashboard Search        | +- |
+| Health                         | + |
+| Organisation                   | + |
+| Other                          | + |
+| Plugin                         | + |
+| Preferences                    | + |
+| Rbac                           | +- |
+| Snapshot                       | + |
+| Teams                          | + |
+| User                           | + |
 
 
 ### Data source health check

--- a/README.md
+++ b/README.md
@@ -168,32 +168,32 @@ versions of Grafana might not support certain features or subsystems.
 
 ### Overview
 
-| API                            | Status |
-|--------------------------------|---|
-| Admin                          | + |
-| Alerting                       | +- |
+| API | Status |
+|---|---|
+| Admin | + |
+| Alerting | +- |
 | Alerting Notification Channels | + |
-| Alerting Provisioning          | + |
-| Annotations                    | + |
-| Authentication                 | +- |
-| Dashboard                      | + |
-| Dashboard Versions             | + |
-| Dashboard Permissions          | + |
-| Data Source                    | + |
-| Data Source Permissions        | + |
-| External Group Sync            | + |
-| Folder                         | + |
-| Folder Permissions             | + |
-| Folder/Dashboard Search        | +- |
-| Health                         | + |
-| Organisation                   | + |
-| Other                          | + |
-| Plugin                         | + |
-| Preferences                    | + |
-| Rbac                           | +- |
-| Snapshot                       | + |
-| Teams                          | + |
-| User                           | + |
+| Alerting Provisioning | + |
+| Annotations | + |
+| Authentication | +- |
+| Dashboard | + |
+| Dashboard Versions | + |
+| Dashboard Permissions | + |
+| Data Source | + |
+| Data Source Permissions | + |
+| External Group Sync | + |
+| Folder | + |
+| Folder Permissions | + |
+| Folder/Dashboard Search | +- |
+| Health | + |
+| Organisation | + |
+| Other | + |
+| Plugin | + |
+| Preferences | + |
+| Rbac | +- |
+| Snapshot | + |
+| Teams | + |
+| User | + |
 
 
 ### Data source health check

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,8 +20,8 @@ python -m unittest -k preference -vvv
 ```
 
 ### Formatting
-When Creating a PR you can run `poe format` which will help remove code style issues and keep the repo clean.
 
+Before creating a PR, you can run `poe format`, in order to resolve code style issues.
 
 ## Run Grafana
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,9 @@ poe test
 python -m unittest -k preference -vvv
 ```
 
+### Formatting
+When Creating a PR you can run `poe format` which will help remove code style issues and keep the repo clean.
+
 
 ## Run Grafana
 ```

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -23,6 +23,7 @@ from .elements import (
     Notifications,
     Organization,
     Organizations,
+    Plugin,
     Rbac,
     Search,
     Snapshots,
@@ -76,6 +77,7 @@ class GrafanaApi:
         self.annotations = Annotations(self.client)
         self.snapshots = Snapshots(self.client)
         self.notifications = Notifications(self.client)
+        self.plugin = Plugin(self.client)
 
     def connect(self):
         try:

--- a/grafana_client/elements/__init__.py
+++ b/grafana_client/elements/__init__.py
@@ -10,6 +10,7 @@ from .folder import Folder
 from .health import Health
 from .notifications import Notifications
 from .organization import Organization, Organizations
+from .plugin import Plugin
 from .rbac import Rbac
 from .search import Search
 from .snapshots import Snapshots

--- a/grafana_client/elements/plugin.py
+++ b/grafana_client/elements/plugin.py
@@ -9,15 +9,15 @@ class Plugin(Base):
         self.client = client
         self.logger = logging.getLogger(__name__)
 
-    def health_check_plugin(self):
+    def health_check_plugin(self, pluginId):
         """
         :return:
         """
-        path = "/healthz"
+        path = "/plugins/%s/health" % pluginId
         r = self.client.GET(path)
         return r
 
-    def get_plugins(self):
+    def get_installed_plugins(self):
         """
         :return:
         """
@@ -25,7 +25,7 @@ class Plugin(Base):
         r = self.client.GET(path)
         return r
 
-    def install_plugins(self, pluginId, version):
+    def install_plugin(self, pluginId, version):
         """
         : return:
         """
@@ -37,7 +37,7 @@ class Plugin(Base):
             self.logger.info("Skipped installing %s and err = %s", pluginId, ex)
         return None
 
-    def uninstall_plugins(self, pluginId):
+    def uninstall_plugin(self, pluginId):
         """
         : return:
         """
@@ -50,6 +50,9 @@ class Plugin(Base):
         return None
 
     def get_plugin_metrics(self, pluginId):
+        """
+        : return:
+        """
         try:
             path = "/plugins/%s/metrics" % pluginId
             r = self.client.GET(path)

--- a/grafana_client/elements/plugin.py
+++ b/grafana_client/elements/plugin.py
@@ -1,0 +1,59 @@
+import logging
+
+from .base import Base
+
+
+class Plugin(Base):
+    def __init__(self, client):
+        super(Plugin, self).__init__(client)
+        self.client = client
+        self.logger = logging.getLogger(__name__)
+
+    def health_check_plugin(self):
+        """
+        :return:
+        """
+        path = "/healthz"
+        r = self.client.GET(path)
+        return r
+
+    def get_plugins(self):
+        """
+        :return:
+        """
+        path = "/plugins?embedded=0"
+        r = self.client.GET(path)
+        return r
+
+    def install_plugins(self, pluginId, version):
+        """
+        : return:
+        """
+        try:
+            path = "/plugins/%s/install" % pluginId
+            r = self.client.POST(path, json={"version": version})
+            return r
+        except Exception as ex:
+            self.logger.info("Skipped installing %s and err = %s", pluginId, ex)
+        return None
+
+    def uninstall_plugins(self, pluginId):
+        """
+        : return:
+        """
+        try:
+            path = "/plugins/%s/uninstall" % pluginId
+            r = self.client.POST(path)
+            return r
+        except Exception as ex:
+            self.logger.info("Skipped uninstalling %s and error = %s", pluginId, ex)
+        return None
+
+    def get_plugin_metrics(self, pluginId):
+        try:
+            path = "/plugins/%s/metrics" % pluginId
+            r = self.client.GET(path)
+            return r
+        except Exception as ex:
+            self.logger.info("Got error in fetching metrics for plugin %s and error = %s", pluginId, ex)
+        return None

--- a/test/elements/test_plugin.py
+++ b/test/elements/test_plugin.py
@@ -1,0 +1,214 @@
+import unittest
+
+import requests_mock
+
+from grafana_client import GrafanaApi
+
+
+class PluginTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
+
+    @requests_mock.Mocker()
+    def test_get_installed_plugins(self, m):
+        m.get(
+            "http://localhost/api/plugins?embedded=0",
+            json=[
+                {
+                    "name": "AWS Data Sources",
+                    "type": "app",
+                    "id": "aws-datasource-provisioner-app",
+                    "enabled": "true",
+                    "pinned": "true",
+                    "info": {
+                        "author": {"name": "Grafana Labs", "url": "https://grafana.com/"},
+                        "description": "AWS Datasource Provisioner",
+                        "links": [],
+                        "logos": {
+                            "small": "public/plugins/aws-datasource-provisioner-app/assets/logo-small.svg",
+                            "large": "public/plugins/aws-datasource-provisioner-app/assets/logo-large.svg",
+                        },
+                        "build": {
+                            "time": 1684358005873,
+                            "repo": "https://github.com/grafana/aws-datasource-provisioner-app",
+                            "branch": "main",
+                            "hash": "cae4b5ad22e487e9e0f81fca8ed801b36f87c733",
+                        },
+                        "screenshots": "",
+                        "version": "1.8.1",
+                        "updated": "2023-05-17",
+                    },
+                    "dependencies": {"grafanaDependency": ">=7.3.0", "grafanaVersion": ">=7.3.0", "plugins": []},
+                    "latestVersion": "",
+                    "hasUpdate": "false",
+                    "defaultNavUrl": "/plugins/aws-datasource-provisioner-app/page/aws-services",
+                    "category": "",
+                    "state": "",
+                    "signature": "valid",
+                    "signatureType": "grafana",
+                    "signatureOrg": "Grafana Labs",
+                },
+                {
+                    "name": "AWS IoT SiteWise",
+                    "type": "datasource",
+                    "id": "grafana-iot-sitewise-datasource",
+                    "enabled": "true",
+                    "pinned": "false",
+                    "info": {
+                        "author": {"name": "Grafana Labs", "url": "https://grafana.com"},
+                        "description": "A managed service to collect, store, organize and monitor data from industrial "
+                        "equipment",
+                        "links": [
+                            {"name": "Website", "url": "https://aws.amazon.com/iot-sitewise/"},
+                            {
+                                "name": "Issue Tracker",
+                                "url": "https://github.com/grafana/iot-sitewise-datasource/issues",
+                            },
+                        ],
+                        "logos": {
+                            "small": "public/plugins/grafana-iot-sitewise-datasource/img/sitewise.svg",
+                            "large": "public/plugins/grafana-iot-sitewise-datasource/img/sitewise.svg",
+                        },
+                        "build": {
+                            "time": 1692806526291,
+                            "repo": "https://github.com/grafana/iot-sitewise-datasource",
+                            "branch": "main",
+                            "hash": "a56fdf241cf677e025530d484472a0c838f05b79",
+                        },
+                        "screenshots": [],
+                        "version": "1.11.0",
+                        "updated": "2023-08-23",
+                    },
+                    "dependencies": {"grafanaDependency": ">=8.5.0", "grafanaVersion": "8.5.0", "plugins": []},
+                    "latestVersion": "",
+                    "hasUpdate": "false",
+                    "defaultNavUrl": "/plugins/grafana-iot-sitewise-datasource/",
+                    "category": "iot",
+                    "state": "",
+                    "signature": "unsigned",
+                    "signatureType": "",
+                    "signatureOrg": "",
+                },
+                {
+                    "name": "AWS IoT TwinMaker App",
+                    "type": "app",
+                    "id": "grafana-iot-twinmaker-app",
+                    "enabled": "true",
+                    "pinned": "true",
+                    "info": {
+                        "author": {"name": "AWS IoT TwinMaker", "url": "https://aws.amazon.com"},
+                        "description": "Create end-user 3D digital twin applications to monitor industrial operations "
+                        "with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and"
+                        "easier for developers to create digital replicas of real-world systems, "
+                        "helping more customers realize the potential of digital twins to optimize operations.",
+                        "links": [{"name": "Website", "url": "https://github.com/grafana/grafana-iot-twinmaker-app"}],
+                        "logos": {
+                            "small": "public/plugins/grafana-iot-twinmaker-app/img/AWS-IoT-TwinMaker.png",
+                            "large": "public/plugins/grafana-iot-twinmaker-app/img/AWS-IoT-TwinMaker.png",
+                        },
+                        "build": {
+                            "time": 1684967559156,
+                            "repo": "https://github.com/grafana/grafana-iot-twinmaker-app",
+                            "branch": "main",
+                            "hash": "bc9c49f1b66c6146d17667e733b319eae967504b",
+                        },
+                        "screenshots": [],
+                        "version": "1.6.2",
+                        "updated": "2023-05-24",
+                    },
+                    "dependencies": {"grafanaDependency": ">=8.4.0", "grafanaVersion": "8.4.0", "plugins": []},
+                    "latestVersion": "",
+                    "hasUpdate": "false",
+                    "defaultNavUrl": "/plugins/grafana-iot-twinmaker-app/",
+                    "category": "iot",
+                    "state": "",
+                    "signature": "unsigned",
+                    "signatureType": "",
+                    "signatureOrg": "",
+                },
+                {
+                    "name": "Akumuli",
+                    "type": "datasource",
+                    "id": "akumuli-datasource",
+                    "enabled": "true",
+                    "pinned": "false",
+                    "info": {
+                        "author": {"name": "Eugene Lazin", "url": "https://akumuli.org"},
+                        "description": "Datasource plugin for Akumuli time-series database",
+                        "links": [{"name": "Project site", "url": "https://github.com/akumuli/Akumuli"}],
+                        "logos": {
+                            "small": "public/plugins/akumuli-datasource/img/logo.svg.png",
+                            "large": "public/plugins/akumuli-datasource/img/logo.svg.png",
+                        },
+                        "build": {},
+                        "screenshots": "",
+                        "version": "1.3.12",
+                        "updated": "2019-12-19",
+                    },
+                    "dependencies": {"grafanaDependency": "", "grafanaVersion": "4.5.x", "plugins": []},
+                    "latestVersion": "",
+                    "hasUpdate": "false",
+                    "defaultNavUrl": "/plugins/akumuli-datasource/",
+                    "category": "",
+                    "state": "",
+                    "signature": "unsigned",
+                    "signatureType": "",
+                    "signatureOrg": "",
+                },
+                {
+                    "name": "Alert list",
+                    "type": "panel",
+                    "id": "alertlist",
+                    "enabled": "true",
+                    "pinned": "false",
+                    "info": {
+                        "author": {"name": "Grafana Labs", "url": "https://grafana.com"},
+                        "description": "Shows list of alerts and their current status",
+                        "links": "null",
+                        "logos": {
+                            "small": "public/app/plugins/panel/alertlist/img/icn-singlestat-panel.svg",
+                            "large": "public/app/plugins/panel/alertlist/img/icn-singlestat-panel.svg",
+                        },
+                        "build": {},
+                        "screenshots": "null",
+                        "version": "",
+                        "updated": "",
+                    },
+                    "dependencies": {"grafanaDependency": "", "grafanaVersion": "*", "plugins": []},
+                    "latestVersion": "",
+                    "hasUpdate": "false",
+                    "defaultNavUrl": "/plugins/alertlist/",
+                    "category": "",
+                    "state": "",
+                    "signature": "internal",
+                    "signatureType": "",
+                    "signatureOrg": "",
+                },
+            ],
+        )
+        plugins = self.grafana.plugin.get_installed_plugins()
+        self.assertTrue(len(plugins), 6)
+
+    @requests_mock.Mocker()
+    def test_install_plugin(self, m):
+        m.post("http://localhost/api/plugins/alertlist/install", json={"message": "Plugin alertlist installed"})
+        response = self.grafana.plugin.install_plugin(pluginId="alertlist", version="1.3.12")
+        self.assertEqual(response["message"], "Plugin alertlist installed")
+
+    @requests_mock.Mocker()
+    def test_uninstall_plugin(self, m):
+        m.post("http://localhost/api/plugins/alertlist/uninstall", json={"message": "Plugin alertlist uninstalled"})
+        response = self.grafana.plugin.uninstall_plugin(pluginId="alertlist")
+        self.assertEqual(response["message"], "Plugin alertlist uninstalled")
+
+    @requests_mock.Mocker()
+    def test_get_plugin_health(self, m):
+        m.get("http://localhost/api/plugins/alertlist/health", json={"message": "Plugin alertlist healthy"})
+        response = self.grafana.plugin.health_check_plugin(pluginId="alertlist")
+        self.assertEqual(response["message"], "Plugin alertlist healthy")
+
+    @requests_mock.Mocker()
+    def test_get_plugin_metrics(self, m):
+        m.get("http://localhost/api/plugins/grafana-timestream-datasource/metrics", json={"message": "Not found"})
+        response = self.grafana.plugin.get_plugin_metrics(pluginId="grafana-timestream-datasource")
+        self.assertEqual(response["message"], "Not found")


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change or which issue is fixed (fixes #(issue)). -->

While working with Grafana I found this amazing python client, I used it to explore the plugin Installation feature using python program. While Install/unInstall APIs are not explicitly called out in Grafana API document. I found it useful to have the base layer on top of which community can build examples and write their own version of how to manage plugins via APIs.

Plugin API link : https://github.com/grafana/grafana/blob/v9.4.x/pkg/api/api.go#L423 

Please provide feedback for improvement needed and I should be able to incorporate.


## Checklist

- [ ] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
