### PR TITLE
Improve `smartquery` and `query_factory` beyond data source health checks

### DIFF
--- a/examples/datasource-smartquery.py
+++ b/examples/datasource-smartquery.py
@@ -4,23 +4,41 @@ About
 
 Example program for submitting a query to a data source.
 
-While the ``--query`` option is obligatory, the ``--store`` option is not.
+While the ``--query`` option is obligatory, the ``--attr`` option is not.
 It will be used to designate the ``database`` name, with e.g. InfluxDB,
-or the ``metric`` name, with e.g. Prometheus.
+or the ``queryType`` name, with e.g. Loki.
 
 Synopsis
 ========
 ::
-
     # Query the InfluxDB 1.x data source on `play.grafana.org`.
     python examples/datasource-smartquery.py --uid=000000002 --query="SHOW RETENTION POLICIES on _internal"
-    python examples/datasource-smartquery.py --uid=000000002 --store=site --query="SHOW FIELD KEYS"
+    python examples/datasource-smartquery.py --uid=000000002 --attr "database:site" --query="SHOW FIELD KEYS"
+    python examples/datasource-smartquery.py --uid 000000002 --query "SELECT sum(\"value\") FROM \"logins.count\" WHERE time >= now() - 5m and time <= now() GROUP BY time(10s) fill(null)"
+
+    #Query the InfluxDB+flux on https://play.grafana.org
+    # fix me : query invalid !
+    python examples/datasource-smartquery.py \
+        --uid M3k6ZPrnz \
+        --query "from(bucket: \"example-bucket\")\\n|> range(start: -1h)|> filter(fn: (r) => r._measurement == \"example-measurement\" and r._field == \"example-field\")"
+
+    // Query the Grafite
+    python examples/datasource-smartquery.py --uid 000000001 --query "aliasByNode(apps.fakesite.web_server_02.counters.requests.count,2)"
 
     # Query the Prometheus data source on `play.grafana.org`.
-    # FIXME: Does not work yet.
-    python \
-        examples/datasource-smartquery.py --uid=000000008 --store=node_boot_time \
+    python examples/datasource-smartquery.py \
+        --uid=000000008 \
         --query='time() - node_boot_time_seconds{job="node", instance=~"demo.do.prometheus.io:.*"}'
+
+    # Query the Loki data source on `play.grafana.org`.
+    python examples/datasource-smartquery.py \
+        --uid=NX9d1VH7k \
+        --query "bytes_over_time({filename=~\".+/json_access.+\", job=~\".*\", instance=~\".*\"}[5m])" \
+        --attr "queryType:instant"
+    python examples/datasource-smartquery.py \
+        --uid=NX9d1VH7k \
+        --query "sum by (status) (count_over_time({filename=~\".+/json_access.+\", job=~\".*\", instance=~\".*\"} | json |  __error__=\"\" [5m]))" \
+        --attr "legendFormat:HTTP Status {{status}}"
 
 """
 import json
@@ -39,17 +57,28 @@ logger = logging.getLogger(__name__)
 def run(grafana: GrafanaApi):
     parser = OptionParser()
     parser.add_option("--uid", dest="uid", help="Data source UID")
-    parser.add_option("--store", dest="store", help="Database or metric to be addressed")
+    # replace by --attr "database:<store>" or --attr "metric:<metric>"
+    # parser.add_option("--store", dest="store", help="Database or metric to be addressed")
     parser.add_option("--query", dest="query", help="Query expression")
+    parser.add_option("--attr", dest="attrs", action="append", help="key:value pair attribute to send into query")
     (options, args) = parser.parse_args()
     if not options.uid:
         parser.error("Option --uid required")
     if not options.query:
         parser.error("Option --query required")
 
+    attributes = {
+    }
+    if options.attrs is not None and len(options.attrs) > 0 :
+        for attr in options.attrs:
+            (key, val) = attr.split(":")
+            attributes[key] = val
+
     # Query the data source by UID.
     response = grafana.datasource.smartquery(
-        DatasourceIdentifier(uid=options.uid), expression=options.query, store=options.store
+        DatasourceIdentifier(uid=options.uid),
+        options.query,
+        attrs=attributes,
     )
 
     # Display the outcome in JSON format.

--- a/examples/datasource-smartquery.py
+++ b/examples/datasource-smartquery.py
@@ -22,7 +22,7 @@ Synopsis
         --uid M3k6ZPrnz \
         --query "from(bucket: \"example-bucket\")\\n|> range(start: -1h)|> filter(fn: (r) => r._measurement == \"example-measurement\" and r._field == \"example-field\")"
 
-    // Query the Grafite
+    // Query the Grafite datasource on https://play.grafana.org
     python examples/datasource-smartquery.py --uid 000000001 --query "aliasByNode(apps.fakesite.web_server_02.counters.requests.count,2)"
 
     # Query the Prometheus data source on `play.grafana.org`.

--- a/examples/datasource-smartquery.py
+++ b/examples/datasource-smartquery.py
@@ -16,13 +16,13 @@ Synopsis
     python examples/datasource-smartquery.py --uid=000000002 --attr "database:site" --query="SHOW FIELD KEYS"
     python examples/datasource-smartquery.py --uid 000000002 --query "SELECT sum(\"value\") FROM \"logins.count\" WHERE time >= now() - 5m and time <= now() GROUP BY time(10s) fill(null)"
 
-    #Query the InfluxDB+flux on https://play.grafana.org
+    # Query the InfluxDB+flux on https://play.grafana.org
     # fix me : query invalid !
     python examples/datasource-smartquery.py \
         --uid M3k6ZPrnz \
         --query "from(bucket: \"example-bucket\")\\n|> range(start: -1h)|> filter(fn: (r) => r._measurement == \"example-measurement\" and r._field == \"example-field\")"
 
-    // Query the Grafite datasource on https://play.grafana.org
+    # Query the Grafite datasource on https://play.grafana.org
     python examples/datasource-smartquery.py --uid 000000001 --query "aliasByNode(apps.fakesite.web_server_02.counters.requests.count,2)"
 
     # Query the Prometheus data source on `play.grafana.org`.

--- a/examples/datasource-smartquery.py
+++ b/examples/datasource-smartquery.py
@@ -42,7 +42,7 @@ Synopsis
         --query "sum by (status) (count_over_time({filename=~\".+/json_access.+\", job=~\".*\", instance=~\".*\"} | json |  __error__=\"\" [5m]))" \
         --attr "legendFormat:HTTP Status {{status}}"
 
-"""
+"""  # noqa: E501
 import json
 import logging
 from optparse import OptionParser
@@ -69,9 +69,8 @@ def run(grafana: GrafanaApi):
     if not options.query:
         parser.error("Option --query required")
 
-    attributes = {
-    }
-    if options.attrs is not None and len(options.attrs) > 0 :
+    attributes = {}
+    if options.attrs is not None and len(options.attrs) > 0:
         for attr in options.attrs:
             (key, val) = attr.split(":")
             attributes[key] = val

--- a/grafana_client/elements/__init__.py
+++ b/grafana_client/elements/__init__.py
@@ -6,7 +6,6 @@ from .base import Base
 from .dashboard import Dashboard
 from .dashboard_versions import DashboardVersions
 from .datasource import Datasource
-from .health import Health
 from .folder import Folder
 from .health import Health
 from .notifications import Notifications

--- a/grafana_client/elements/__init__.py
+++ b/grafana_client/elements/__init__.py
@@ -6,6 +6,7 @@ from .base import Base
 from .dashboard import Dashboard
 from .dashboard_versions import DashboardVersions
 from .datasource import Datasource
+from .health import Health
 from .folder import Folder
 from .health import Health
 from .notifications import Notifications

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -16,6 +16,7 @@ from .base import Base
 logger = logging.getLogger(__name__)
 
 VERSION_9 = LooseVersion("9")
+VERSION_7 = LooseVersion("7")
 VERBOSE = False
 
 
@@ -533,9 +534,14 @@ class Datasource(Base):
                     message = f"Invalid response. {reason}"
 
             elif datasource_type == "loki":
-                if "status" in response and response["status"] == "success":
-                    message = "Success"
-                    success = True
+                if self.api.version:
+                    if LooseVersion(self.api.version) == VERSION_7:
+                        if "status" in response and response["status"] == "success":
+                            message = "Success"
+                            success = True
+                    elif "results" in response and "test" in response["results"]:
+                        message = "Success"
+                        success = True
                 else:
                     message = response["message"]
 

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -308,78 +308,6 @@ class Datasource(Base):
         r = self.client.POST(post_series_path, data={"match[]": match, "start": start, "end": end})
         return r
 
-    def smartquery_old(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, store: Optional[str] = None):
-        """
-        Send a query to the designated data source and return its response.
-
-        TODO: This is by far not complete. The `query_factory` function has to
-              be made more elaborate in order to query different data source
-              types.
-        """
-
-        if isinstance(datasource, DatasourceIdentifier):
-            datasource = self.get(datasource)
-
-        datasource_id = datasource["id"]
-        datasource_type = datasource["type"]
-        datasource_dialect = datasource.get("jsonData", {}).get("version", "InfluxQL")
-        access_type = datasource["access"]
-
-        # Sanity checks.
-        if not expression:
-            raise ValueError("Expression must be given")
-
-        # Build the query payload. Each data source has different query attributes.
-        query = query_factory(datasource, expression, store)
-
-        logger.info(f"Submitting query: {query}")
-
-        # Compute request method, body, and endpoint.
-        send_request = self.client.POST
-
-        # Certain data sources like InfluxDB 1.x, still use the `/datasources/proxy` route.
-        if datasource_type == "influxdb" and datasource_dialect == "InfluxQL":
-            url = f"/datasources/proxy/{datasource_id}/query"
-            if store is not None:
-                url += f"?db={store}"
-            payload = {"q": query["q"]}
-            request_kwargs = {"data": payload}
-
-        elif datasource_type == "graphite":
-            url = f"/datasources/proxy/{datasource_id}/render"
-            request_kwargs = {"data": query}
-
-        # This case is very special. It is used for Elasticsearch and Testdata.
-        elif expression.startswith("url://"):
-            url = expression.replace("url://", "")
-            url = url.format(
-                datasource_id=datasource.get("id"),
-                datasource_uid=datasource.get("uid"),
-                database_name=datasource.get("database"),
-            )
-            request_kwargs = {}
-            send_request = self.client.GET
-
-        # For all others, use the generic data source communication endpoint.
-        elif access_type in ["server", "proxy"]:
-            url = "/ds/query"
-            payload = {"queries": [query]}
-            request_kwargs = {"json": payload}
-
-        else:
-            raise NotImplementedError(f"Unable to submit query to data source with access type '{access_type}'")
-
-        # Submit query.
-        try:
-            r = send_request(url, **request_kwargs)
-            # logger.debug(f"Response from generic data source query: {r}")
-            return r
-        except (GrafanaClientError, GrafanaServerError) as ex:
-            logger.error(
-                f"Querying data source failed. id={datasource_id}, type={datasource_type}. "
-                f"Reason: {ex}. Response: {ex.response or '<empty>'}"
-            )
-            raise
 #**********************************************************************************
     def smartquery(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, attrs: Optional[dict] = None, request: Optional[dict] = None):
         """
@@ -431,8 +359,8 @@ class Datasource(Base):
             request_kwargs = {"data": request["data"]}
 
         # This case is very special. It is used for Elasticsearch and Testdata.
-        elif expression.startswith("url://"):
-            url = expression.replace("url://", "")
+        elif 'url' in request and model['url'].startswith("url://"):
+            url = model['url'].replace("url://", "")
             url = url.format(
                 datasource_id=datasource.get("id"),
                 datasource_uid=datasource.get("uid"),
@@ -441,6 +369,21 @@ class Datasource(Base):
             request_kwargs = {}
             send_request = self.client.GET
 
+        elif datasource_type in ("prometheus", "loki") and LooseVersion(self.api.version) <= VERSION_7:
+            if request["data"]["format"] != "table":
+                return self.query(
+                    datasource.get("id"),
+                    request["expr"],
+                    request["data"]["to"],
+                )
+            else:
+                return self.query_range(
+                    datasource.get("id"),
+                    request["expr"],
+                    request["data"]["from"],
+                    request["data"]["to"],
+                    request["data"]["step"],
+                )
         # For all others, use the generic data source communication endpoint.
         elif access_type in ["server", "proxy"]:
             url = "/ds/query"

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -307,6 +307,78 @@ class Datasource(Base):
         r = self.client.POST(post_series_path, data={"match[]": match, "start": start, "end": end})
         return r
 
+    def smartquery_old(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, store: Optional[str] = None):
+        """
+        Send a query to the designated data source and return its response.
+
+        TODO: This is by far not complete. The `query_factory` function has to
+              be made more elaborate in order to query different data source
+              types.
+        """
+
+        if isinstance(datasource, DatasourceIdentifier):
+            datasource = self.get(datasource)
+
+        datasource_id = datasource["id"]
+        datasource_type = datasource["type"]
+        datasource_dialect = datasource.get("jsonData", {}).get("version", "InfluxQL")
+        access_type = datasource["access"]
+
+        # Sanity checks.
+        if not expression:
+            raise ValueError("Expression must be given")
+
+        # Build the query payload. Each data source has different query attributes.
+        query = query_factory(datasource, expression, store)
+
+        logger.info(f"Submitting query: {query}")
+
+        # Compute request method, body, and endpoint.
+        send_request = self.client.POST
+
+        # Certain data sources like InfluxDB 1.x, still use the `/datasources/proxy` route.
+        if datasource_type == "influxdb" and datasource_dialect == "InfluxQL":
+            url = f"/datasources/proxy/{datasource_id}/query"
+            if store is not None:
+                url += f"?db={store}"
+            payload = {"q": query["q"]}
+            request_kwargs = {"data": payload}
+
+        elif datasource_type == "graphite":
+            url = f"/datasources/proxy/{datasource_id}/render"
+            request_kwargs = {"data": query}
+
+        # This case is very special. It is used for Elasticsearch and Testdata.
+        elif expression.startswith("url://"):
+            url = expression.replace("url://", "")
+            url = url.format(
+                datasource_id=datasource.get("id"),
+                datasource_uid=datasource.get("uid"),
+                database_name=datasource.get("database"),
+            )
+            request_kwargs = {}
+            send_request = self.client.GET
+
+        # For all others, use the generic data source communication endpoint.
+        elif access_type in ["server", "proxy"]:
+            url = "/ds/query"
+            payload = {"queries": [query]}
+            request_kwargs = {"json": payload}
+
+        else:
+            raise NotImplementedError(f"Unable to submit query to data source with access type '{access_type}'")
+
+        # Submit query.
+        try:
+            r = send_request(url, **request_kwargs)
+            # logger.debug(f"Response from generic data source query: {r}")
+            return r
+        except (GrafanaClientError, GrafanaServerError) as ex:
+            logger.error(
+                f"Querying data source failed. id={datasource_id}, type={datasource_type}. "
+                f"Reason: {ex}. Response: {ex.response or '<empty>'}"
+            )
+            raise
 #**********************************************************************************
     def smartquery(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, attrs: Optional[dict] = None, request: Optional[dict] = None):
         """
@@ -332,11 +404,10 @@ class Datasource(Base):
             model = {
                 "refId": "test",
             }
-            if expression is not None:
-                if attrs is not None:
-                    model.update(attrs)
-                if attrs is None or ( attrs is not None and 'query' not in attrs):
-                    model['query'] = expression
+            if expression is not None and ( attrs is None or (attrs is not None and 'query' not in attrs)):
+                model['query'] = expression
+            if attrs is not None:
+                model.update(attrs)
             request = query_factory(datasource, model)
 
         # Compute request method, body, and endpoint.
@@ -359,15 +430,15 @@ class Datasource(Base):
             request_kwargs = {"data": request["data"]}
 
         # This case is very special. It is used for Elasticsearch and Testdata.
-        # elif expression.startswith("url://"):
-        #     url = expression.replace("url://", "")
-        #     url = url.format(
-        #         datasource_id=datasource.get("id"),
-        #         datasource_uid=datasource.get("uid"),
-        #         database_name=datasource.get("database"),
-        #     )
-        #     request_kwargs = {}
-        #     send_request = self.client.GET
+        elif expression.startswith("url://"):
+            url = expression.replace("url://", "")
+            url = url.format(
+                datasource_id=datasource.get("id"),
+                datasource_uid=datasource.get("uid"),
+                database_name=datasource.get("database"),
+            )
+            request_kwargs = {}
+            send_request = self.client.GET
 
         # For all others, use the generic data source communication endpoint.
         elif access_type in ["server", "proxy"]:

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -307,78 +307,6 @@ class Datasource(Base):
         r = self.client.POST(post_series_path, data={"match[]": match, "start": start, "end": end})
         return r
 
-    def smartquery_old(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, store: Optional[str] = None):
-        """
-        Send a query to the designated data source and return its response.
-
-        TODO: This is by far not complete. The `query_factory` function has to
-              be made more elaborate in order to query different data source
-              types.
-        """
-
-        if isinstance(datasource, DatasourceIdentifier):
-            datasource = self.get(datasource)
-
-        datasource_id = datasource["id"]
-        datasource_type = datasource["type"]
-        datasource_dialect = datasource.get("jsonData", {}).get("version", "InfluxQL")
-        access_type = datasource["access"]
-
-        # Sanity checks.
-        if not expression:
-            raise ValueError("Expression must be given")
-
-        # Build the query payload. Each data source has different query attributes.
-        query = query_factory(datasource, expression, store)
-
-        logger.info(f"Submitting query: {query}")
-
-        # Compute request method, body, and endpoint.
-        send_request = self.client.POST
-
-        # Certain data sources like InfluxDB 1.x, still use the `/datasources/proxy` route.
-        if datasource_type == "influxdb" and datasource_dialect == "InfluxQL":
-            url = f"/datasources/proxy/{datasource_id}/query"
-            if store is not None:
-                url += f"?db={store}"
-            payload = {"q": query["q"]}
-            request_kwargs = {"data": payload}
-
-        elif datasource_type == "graphite":
-            url = f"/datasources/proxy/{datasource_id}/render"
-            request_kwargs = {"data": query}
-
-        # This case is very special. It is used for Elasticsearch and Testdata.
-        elif expression.startswith("url://"):
-            url = expression.replace("url://", "")
-            url = url.format(
-                datasource_id=datasource.get("id"),
-                datasource_uid=datasource.get("uid"),
-                database_name=datasource.get("database"),
-            )
-            request_kwargs = {}
-            send_request = self.client.GET
-
-        # For all others, use the generic data source communication endpoint.
-        elif access_type in ["server", "proxy"]:
-            url = "/ds/query"
-            payload = {"queries": [query]}
-            request_kwargs = {"json": payload}
-
-        else:
-            raise NotImplementedError(f"Unable to submit query to data source with access type '{access_type}'")
-
-        # Submit query.
-        try:
-            r = send_request(url, **request_kwargs)
-            # logger.debug(f"Response from generic data source query: {r}")
-            return r
-        except (GrafanaClientError, GrafanaServerError) as ex:
-            logger.error(
-                f"Querying data source failed. id={datasource_id}, type={datasource_type}. "
-                f"Reason: {ex}. Response: {ex.response or '<empty>'}"
-            )
-            raise
 #**********************************************************************************
     def smartquery(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, attrs: Optional[dict] = None, request: Optional[dict] = None):
         """
@@ -404,9 +332,11 @@ class Datasource(Base):
             model = {
                 "refId": "test",
             }
-            if expression is not None and 'query' not in attrs:
-                model['query'] = expression
-            model.update(attrs)
+            if expression is not None:
+                if attrs is not None:
+                    model.update(attrs)
+                if attrs is None or ( attrs is not None and 'query' not in attrs):
+                    model['query'] = expression
             request = query_factory(datasource, model)
 
         # Compute request method, body, and endpoint.

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -4,6 +4,7 @@ import time
 import warnings
 from distutils.version import LooseVersion
 from typing import Dict, Optional, Tuple, Union
+from urllib.parse import urlencode
 
 from requests import ReadTimeout
 
@@ -306,7 +307,7 @@ class Datasource(Base):
         r = self.client.POST(post_series_path, data={"match[]": match, "start": start, "end": end})
         return r
 
-    def smartquery(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, store: Optional[str] = None):
+    def smartquery_old(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, store: Optional[str] = None):
         """
         Send a query to the designated data source and return its response.
 
@@ -363,6 +364,85 @@ class Datasource(Base):
             url = "/ds/query"
             payload = {"queries": [query]}
             request_kwargs = {"json": payload}
+
+        else:
+            raise NotImplementedError(f"Unable to submit query to data source with access type '{access_type}'")
+
+        # Submit query.
+        try:
+            r = send_request(url, **request_kwargs)
+            # logger.debug(f"Response from generic data source query: {r}")
+            return r
+        except (GrafanaClientError, GrafanaServerError) as ex:
+            logger.error(
+                f"Querying data source failed. id={datasource_id}, type={datasource_type}. "
+                f"Reason: {ex}. Response: {ex.response or '<empty>'}"
+            )
+            raise
+#**********************************************************************************
+    def smartquery(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, attrs: Optional[dict] = None, request: Optional[dict] = None):
+        """
+        Send a query to the designated data source and return its response.
+
+        TODO: This is by far not complete. The `query_factory` function has to
+            be made more elaborate in order to query different data source
+                types.
+        """
+
+        if isinstance(datasource, DatasourceIdentifier):
+            datasource = self.get(datasource)
+
+        datasource_id = datasource["id"]
+        datasource_type = datasource["type"]
+        datasource_dialect = datasource.get("jsonData", {}).get("version", "InfluxQL")
+        access_type = datasource["access"]
+
+        # Sanity checks.
+        if not request and not expression:
+            raise ValueError("request or expression must be given")
+        elif not request:
+            model = {
+                "refId": "test",
+            }
+            if expression is not None and 'query' not in attrs:
+                model['query'] = expression
+            model.update(attrs)
+            request = query_factory(datasource, model)
+
+        # Compute request method, body, and endpoint.
+        if "method" in request and isinstance(request["method"], str):
+            if request['method'] == 'POST':
+                send_request = self.client.POST
+            else:
+                send_request = self.client.GET
+
+        logger.info(f"Submitting request: {request}")
+
+        # Certain data sources like InfluxDB 1.x, still use the `/datasources/proxy` route.
+        if datasource_type == "influxdb" and datasource_dialect == "InfluxQL":
+            url = f"/datasources/proxy/{datasource_id}/query"
+            url += '?' + urlencode(request['params'])
+            request_kwargs = {"data": request["data"]}
+
+        elif datasource_type == "graphite":
+            url = f"/datasources/proxy/{datasource_id}/render"
+            request_kwargs = {"data": request["data"]}
+
+        # This case is very special. It is used for Elasticsearch and Testdata.
+        # elif expression.startswith("url://"):
+        #     url = expression.replace("url://", "")
+        #     url = url.format(
+        #         datasource_id=datasource.get("id"),
+        #         datasource_uid=datasource.get("uid"),
+        #         database_name=datasource.get("database"),
+        #     )
+        #     request_kwargs = {}
+        #     send_request = self.client.GET
+
+        # For all others, use the generic data source communication endpoint.
+        elif access_type in ["server", "proxy"]:
+            url = "/ds/query"
+            request_kwargs = {"json": request["data"]}
 
         else:
             raise NotImplementedError(f"Unable to submit query to data source with access type '{access_type}'")

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -370,7 +370,8 @@ class Datasource(Base):
             send_request = self.client.GET
 
         elif datasource_type in ("prometheus", "loki") and LooseVersion(self.api.version) <= VERSION_7:
-            if request["data"]["format"] != "table":
+            if "queries" in request["data"] and len(request["data"]["queries"]) > 0 \
+                and "instant" in request["data"]["queries"][0] and request["data"]["queries"][0]["instant"]:
                 return self.query(
                     datasource.get("id"),
                     request["expr"],

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -308,8 +308,13 @@ class Datasource(Base):
         r = self.client.POST(post_series_path, data={"match[]": match, "start": start, "end": end})
         return r
 
-#**********************************************************************************
-    def smartquery(self, datasource: Union[DatasourceIdentifier, Dict], expression: str, attrs: Optional[dict] = None, request: Optional[dict] = None):
+    def smartquery(
+        self,
+        datasource: Union[DatasourceIdentifier, Dict],
+        expression: str,
+        attrs: Optional[dict] = None,
+        request: Optional[dict] = None,
+    ):
         """
         Send a query to the designated data source and return its response.
 
@@ -333,15 +338,15 @@ class Datasource(Base):
             model = {
                 "refId": "test",
             }
-            if expression is not None and ( attrs is None or (attrs is not None and 'query' not in attrs)):
-                model['query'] = expression
+            if expression is not None and (attrs is None or (attrs is not None and "query" not in attrs)):
+                model["query"] = expression
             if attrs is not None:
                 model.update(attrs)
             request = query_factory(datasource, model)
 
         # Compute request method, body, and endpoint.
         if "method" in request and isinstance(request["method"], str):
-            if request['method'] == 'POST':
+            if request["method"] == "POST":
                 send_request = self.client.POST
             else:
                 send_request = self.client.GET
@@ -351,7 +356,7 @@ class Datasource(Base):
         # Certain data sources like InfluxDB 1.x, still use the `/datasources/proxy` route.
         if datasource_type == "influxdb" and datasource_dialect == "InfluxQL":
             url = f"/datasources/proxy/{datasource_id}/query"
-            url += '?' + urlencode(request['params'])
+            url += "?" + urlencode(request["params"])
             request_kwargs = {"data": request["data"]}
 
         elif datasource_type == "graphite":
@@ -359,8 +364,8 @@ class Datasource(Base):
             request_kwargs = {"data": request["data"]}
 
         # This case is very special. It is used for Elasticsearch and Testdata.
-        elif 'url' in request and model['url'].startswith("url://"):
-            url = model['url'].replace("url://", "")
+        elif "url" in request and model["url"].startswith("url://"):
+            url = model["url"].replace("url://", "")
             url = url.format(
                 datasource_id=datasource.get("id"),
                 datasource_uid=datasource.get("uid"),
@@ -370,8 +375,12 @@ class Datasource(Base):
             send_request = self.client.GET
 
         elif datasource_type in ("prometheus", "loki") and LooseVersion(self.api.version) <= VERSION_7:
-            if "queries" in request["data"] and len(request["data"]["queries"]) > 0 \
-                and "instant" in request["data"]["queries"][0] and request["data"]["queries"][0]["instant"]:
+            if (
+                "queries" in request["data"]
+                and len(request["data"]["queries"]) > 0
+                and "instant" in request["data"]["queries"][0]
+                and request["data"]["queries"][0]["instant"]
+            ):
                 return self.query(
                     datasource.get("id"),
                     request["expr"],

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -183,14 +183,22 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             request["data"] = query
 
         elif dialect == "Flux":
-            query.update(
-                {
-                    # "intervalMs": 60000,
-                    "maxDataPoints": 1,
-                    "query": expression,
-                }
-            )
-            request["data"] = query
+
+            query = {
+                "datasource": {
+                    "type": datasource["type"],
+                    "uid": datasource.get("uid"),
+                },
+                "datasourceId": datasource.get("id"),
+                # "exemplar": False,
+                "query": expression,
+            }
+
+            attrs = [
+                { "name": "intervalMs", "default": 15000, },
+                { "name": "maxDataPoints", "default": None, },
+                { "name": "refId", "default": "test", },
+            ]
         else:
             raise KeyError(f"InfluxDB dialect '{dialect}' unknown")
 
@@ -283,7 +291,7 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
     else:
         raise NotImplementedError(f"Unknown data source type: {datasource_type}")
 
-    if attrs is not None:
+    if attrs is not None and query is not None and isinstance(query, dict):
         for attr in attrs:
             value = attr["default"]
             if attr["name"] in model:

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -303,6 +303,9 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             if 'time_to' not in model:
                 model['time_to'] = int( now.timestamp() )
 
+        if 'instant' in query and query['instant']:
+            model['time_from'] = model['time_to']
+
         payload = {
             "queries": [query],
             "from": str(model['time_from']*1000),

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -195,8 +195,8 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             }
 
             attrs = [
-                { "name": "intervalMs", "default": 15000, },
-                { "name": "maxDataPoints", "default": None, },
+                { "name": "intervalMs", "default": 30000, },
+                { "name": "maxDataPoints", "default": 1441, },
                 { "name": "refId", "default": "test", },
             ]
         else:
@@ -221,7 +221,7 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             { "name": "intervalMs", "default": 60000, },
             { "name": "legendFormat", "default": "", },
             { "name": "maxLines", "default": 1000, },
-            { "name": "maxDataPoints", "default": 1442, },
+            { "name": "maxDataPoints", "default": 1441, },
             { "name": "queryType", "default": "range", },
             { "name": "refId", "default": "test", },
             { "name": "resolution", "default": 1, },
@@ -245,8 +245,8 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
                 "choices": [ "time_series", "table"],
                 # "version": "8.0.0"
             },
-            { "name": "intervalMs", "default": 15000, },
-            { "name": "maxDataPoints", "default": None, },
+            { "name": "intervalMs", "default": 30000, },
+            { "name": "maxDataPoints", "default": 1441, },
             { "name": "refId", "default": None, },
         ]
 
@@ -270,7 +270,7 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             { "name": "instant", "default": False, },
             { "name": "interval", "default": "", },
             { "name": "intervalFactor", "default": None, },
-            { "name": "intervalMs", "default": 15000, },
+            { "name": "intervalMs", "default": 30000, },
             { "name": "legendFormat", "default": "", },
             { "name": "maxDataPoints", "default": None, },
             { "name": "queryType", "default": "timeSeriesQuery", },

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -115,7 +115,7 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
     return datasource
 
 
-def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
+def query_factory(datasource, model: Optional[dict] = None, expression: Optional[str] = None) -> Union[Dict, str]:
     """
     Create payload suitable for running a query against a Grafana data source.
 
@@ -124,6 +124,11 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
 
     TODO: Complete the list for all popular databases.
     """
+
+    model = model or {}
+    if "query" not in model and expression:
+        model["query"] = expression
+
     request = {
         "method": "POST",
         "data": None,

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -147,7 +147,7 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
     elif datasource_type == "graphite":
         query = {
             "target": expression,
-            "from": "-1h",
+            "from": "-5m",
             "until": "now",
             "format": "json",
             "maxDataPoints": 300

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -4,8 +4,8 @@ About
 Knowledgebase module for filling the missing gaps to access the Grafana API
 more efficiently.
 """
-from typing import Dict, Optional, Union
 from datetime import datetime
+from typing import Dict, Optional, Union
 
 from grafana_client.model import DatasourceModel
 
@@ -143,23 +143,16 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
         query = expression
     elif datasource_type == "grafana-simple-json-datasource":
         query = expression
-    #************************************************************************
+
     elif datasource_type == "graphite":
-        query = {
-            "target": expression,
-            "from": "-5m",
-            "until": "now",
-            "format": "json",
-            "maxDataPoints": 300
-        }
-        if 'time_from' in model:
-            query['from']=model['time_from']
-        if 'time_to' in model:
-            query['until']=model['time_to']
+        query = {"target": expression, "from": "-5m", "until": "now", "format": "json", "maxDataPoints": 300}
+        if "time_from" in model:
+            query["from"] = model["time_from"]
+        if "time_to" in model:
+            query["until"] = model["time_to"]
 
         request["data"] = query
 
-    #************************************************************************
     elif datasource_type == "influxdb":
         dialect = datasource["jsonData"].get("version", "InfluxQL")
         query = {
@@ -177,13 +170,12 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
                 }
             )
             # this drive the how timestamp are rendered in result (string by default, or in milliseconds ms)
-            request["params"] =  { "epoch": "ms" }
-            if 'database' in datasource:
-                request["params"].update({ "db": datasource['database'] })
+            request["params"] = {"epoch": "ms"}
+            if "database" in datasource:
+                request["params"].update({"db": datasource["database"]})
             request["data"] = query
 
         elif dialect == "Flux":
-
             query = {
                 "datasource": {
                     "type": datasource["type"],
@@ -195,9 +187,18 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             }
 
             attrs = [
-                { "name": "intervalMs", "default": 30000, },
-                { "name": "maxDataPoints", "default": 1441, },
-                { "name": "refId", "default": "test", },
+                {
+                    "name": "intervalMs",
+                    "default": 30000,
+                },
+                {
+                    "name": "maxDataPoints",
+                    "default": 1441,
+                },
+                {
+                    "name": "refId",
+                    "default": "test",
+                },
             ]
         else:
             raise KeyError(f"InfluxDB dialect '{dialect}' unknown")
@@ -205,7 +206,6 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
     elif datasource_type == "jaeger":
         query = {}
 
-    #************************************************************************
     elif datasource_type == "loki":
         query = {
             "datasource": {
@@ -218,20 +218,40 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
         }
 
         attrs = [
-            { "name": "intervalMs", "default": 60000, },
-            { "name": "legendFormat", "default": "", },
-            { "name": "maxLines", "default": 1000, },
-            { "name": "maxDataPoints", "default": 1441, },
-            { "name": "queryType", "default": "range", },
-            { "name": "refId", "default": "test", },
-            { "name": "resolution", "default": 1, },
+            {
+                "name": "intervalMs",
+                "default": 60000,
+            },
+            {
+                "name": "legendFormat",
+                "default": "",
+            },
+            {
+                "name": "maxLines",
+                "default": 1000,
+            },
+            {
+                "name": "maxDataPoints",
+                "default": 1441,
+            },
+            {
+                "name": "queryType",
+                "default": "range",
+            },
+            {
+                "name": "refId",
+                "default": "test",
+            },
+            {
+                "name": "resolution",
+                "default": 1,
+            },
         ]
-    
+
     elif datasource_type == "opentsdb":
         query = {}
 
-    #************************************************************************
-    elif datasource_type in ( "postgres", "mssql", "mysql" ):
+    elif datasource_type in ("postgres", "mssql", "mysql"):
         query = {
             "datasource": {
                 "type": datasource["type"],
@@ -241,16 +261,26 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             "rawSql": expression,
         }
         attrs = [
-            { "name": "format", "default": "time_series",
-                "choices": [ "time_series", "table"],
+            {
+                "name": "format",
+                "default": "time_series",
+                "choices": ["time_series", "table"],
                 # "version": "8.0.0"
             },
-            { "name": "intervalMs", "default": 30000, },
-            { "name": "maxDataPoints", "default": 1441, },
-            { "name": "refId", "default": None, },
+            {
+                "name": "intervalMs",
+                "default": 30000,
+            },
+            {
+                "name": "maxDataPoints",
+                "default": 1441,
+            },
+            {
+                "name": "refId",
+                "default": None,
+            },
         ]
 
-    #************************************************************************
     elif datasource_type == "prometheus":
         query = {
             "datasource": {
@@ -263,21 +293,56 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
         }
 
         attrs = [
-            { "name": "format", "default": "time_series",
-                "choices": [ "time_series", "table", "heatmap"],
+            {
+                "name": "format",
+                "default": "time_series",
+                "choices": ["time_series", "table", "heatmap"],
                 # "version": "8.0.0"
             },
-            { "name": "instant", "default": False, },
-            { "name": "interval", "default": "", },
-            { "name": "intervalFactor", "default": None, },
-            { "name": "intervalMs", "default": 30000, },
-            { "name": "legendFormat", "default": "", },
-            { "name": "maxDataPoints", "default": None, },
-            { "name": "queryType", "default": "timeSeriesQuery", },
-            { "name": "refId", "default": "test", },
-            { "name": "requestId", "default": "0test", },
-            { "name": "step", "default": 300, },
-            { "name": "utcOffsetSec", "default": 0, },
+            {
+                "name": "instant",
+                "default": False,
+            },
+            {
+                "name": "interval",
+                "default": "",
+            },
+            {
+                "name": "intervalFactor",
+                "default": None,
+            },
+            {
+                "name": "intervalMs",
+                "default": 30000,
+            },
+            {
+                "name": "legendFormat",
+                "default": "",
+            },
+            {
+                "name": "maxDataPoints",
+                "default": None,
+            },
+            {
+                "name": "queryType",
+                "default": "timeSeriesQuery",
+            },
+            {
+                "name": "refId",
+                "default": "test",
+            },
+            {
+                "name": "requestId",
+                "default": "0test",
+            },
+            {
+                "name": "step",
+                "default": 300,
+            },
+            {
+                "name": "utcOffsetSec",
+                "default": 0,
+            },
         ]
 
     elif datasource_type == "simpod-json-datasource":
@@ -304,20 +369,20 @@ def query_factory(datasource, model: Optional[dict]) -> Union[Dict, str]:
             if value is not None:
                 query[attr["name"]] = value
 
-        if 'time_from' not in model or 'time_to' not in model:
+        if "time_from" not in model or "time_to" not in model:
             now = datetime.now()
-            if 'time_from' not in model:
-                model['time_from'] = int( now.timestamp() ) - 5 *60
-            if 'time_to' not in model:
-                model['time_to'] = int( now.timestamp() )
+            if "time_from" not in model:
+                model["time_from"] = int(now.timestamp()) - 5 * 60
+            if "time_to" not in model:
+                model["time_to"] = int(now.timestamp())
 
-        if 'instant' in query and query['instant']:
-            model['time_from'] = model['time_to']
+        if "instant" in query and query["instant"]:
+            model["time_from"] = model["time_to"]
 
         payload = {
             "queries": [query],
-            "from": str(model['time_from']*1000),
-            "to": str(model['time_to']*1000),
+            "from": str(model["time_from"] * 1000),
+            "to": str(model["time_to"] * 1000),
         }
         request["data"] = payload
 
@@ -330,12 +395,13 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "elasticsearch": "url:///datasources/proxy/{datasource_id}/{database_name}/_mapping",
     "fetzerch-sunandmoon-datasource": "url:///datasources/uid/{datasource_uid}",
     "grafana-simple-json-datasource": "url:///datasources/proxy/{datasource_id}",
-    "graphite": "random-walk.count;dc=asia-1;app=collector;server=000",  # from play.grafana.org explore Grafite datasource.
+    # From play.grafana.org, to explore Graphite datasource.
+    "graphite": "random-walk.count;dc=asia-1;app=collector;server=000",
     "influxdb": "SHOW RETENTION POLICIES on _internal",
     "influxdb+influxql": "SHOW RETENTION POLICIES on _internal",
     "influxdb+flux": "buckets()",
     "jaeger": "url:///datasources/proxy/{datasource_id}/api/services",
-    "loki": "count_over_time({job=~\".+\"} [5m])",
+    "loki": 'count_over_time({job=~".+"} [5m])',
     "mssql": "SELECT 1",
     "mysql": "SELECT 1",
     "opentsdb": "url:///datasources/proxy/{datasource_id}/api/suggest?type=metrics&q=cpu&max=100",

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -319,12 +319,12 @@ HEALTHCHECK_EXPRESSION_MAP = {
     "elasticsearch": "url:///datasources/proxy/{datasource_id}/{database_name}/_mapping",
     "fetzerch-sunandmoon-datasource": "url:///datasources/uid/{datasource_uid}",
     "grafana-simple-json-datasource": "url:///datasources/proxy/{datasource_id}",
-    "graphite": "None",  # TODO: Allow real None's.
+    "graphite": "random-walk.count;dc=asia-1;app=collector;server=000",  # from play.grafana.org explore Grafite datasource.
     "influxdb": "SHOW RETENTION POLICIES on _internal",
     "influxdb+influxql": "SHOW RETENTION POLICIES on _internal",
     "influxdb+flux": "buckets()",
     "jaeger": "url:///datasources/proxy/{datasource_id}/api/services",
-    "loki": "url:///datasources/{datasource_id}/resources/labels?start=1656274994383000000&end=1656275594383000000",
+    "loki": "count_over_time({job=~\".+\"} [5m])",
     "mssql": "SELECT 1",
     "mysql": "SELECT 1",
     "opentsdb": "url:///datasources/proxy/{datasource_id}/api/suggest?type=metrics&q=cpu&max=100",

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -1,5 +1,4 @@
 import unittest
-
 from test.elements.test_datasource_fixtures import (
     DATAFRAME_RESPONSE_HEALTH_PROMETHEUS,
     ELASTICSEARCH_DATASOURCE,
@@ -288,7 +287,9 @@ class DatasourceTestCase(unittest.TestCase):
             json={},
         )
         datasource = INFLUXDB1_DATASOURCE.copy()
-        _ = self.grafana.datasource.smartquery(datasource, "SHOW RETENTION POLICIES on _internal", attrs={ "database": "foobar"})
+        _ = self.grafana.datasource.smartquery(
+            datasource, "SHOW RETENTION POLICIES on _internal", attrs={"database": "foobar"}
+        )
         # TODO: No response payload yet.
 
     @requests_mock.Mocker()
@@ -298,9 +299,7 @@ class DatasourceTestCase(unittest.TestCase):
             json={},
         )
         datasource = ELASTICSEARCH_DATASOURCE.copy()
-        _ = self.grafana.datasource.smartquery(
-            datasource, "url:///datasources/proxy/44/bazqux/_mapping"
-        )
+        _ = self.grafana.datasource.smartquery(datasource, "url:///datasources/proxy/44/bazqux/_mapping")
         # TODO: No response payload yet.
 
     @requests_mock.Mocker()

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -1,4 +1,5 @@
 import unittest
+
 from test.elements.test_datasource_fixtures import (
     DATAFRAME_RESPONSE_HEALTH_PROMETHEUS,
     ELASTICSEARCH_DATASOURCE,
@@ -287,7 +288,7 @@ class DatasourceTestCase(unittest.TestCase):
             json={},
         )
         datasource = INFLUXDB1_DATASOURCE.copy()
-        _ = self.grafana.datasource.smartquery(datasource, "SHOW RETENTION POLICIES on _internal", store="foobar")
+        _ = self.grafana.datasource.smartquery(datasource, "SHOW RETENTION POLICIES on _internal", attrs={ "database": "foobar"})
         # TODO: No response payload yet.
 
     @requests_mock.Mocker()
@@ -298,7 +299,7 @@ class DatasourceTestCase(unittest.TestCase):
         )
         datasource = ELASTICSEARCH_DATASOURCE.copy()
         _ = self.grafana.datasource.smartquery(
-            datasource, "url:///datasources/proxy/44/bazqux/_mapping", store="bazqux"
+            datasource, "url:///datasources/proxy/44/bazqux/_mapping"
         )
         # TODO: No response payload yet.
 

--- a/test/elements/test_datasource_fixtures.py
+++ b/test/elements/test_datasource_fixtures.py
@@ -205,6 +205,9 @@ DATAFRAME_RESPONSE_HEALTH_SELECT1 = {
     "results": {"test": {"frames": [{"schema": {"meta": {"executedQueryString": "SELECT 1"}}}]}}
 }
 
+# TODO: Reflect a real Grafana response for Elasticsearch here.
+DATAFRAME_RESPONSE_HEALTH_ELASTICSEARCH_VALID = {"bazqux": {}}
+
 DATAFRAME_RESPONSE_HEALTH_PROMETHEUS = {
     "results": {
         "test": {


### PR DESCRIPTION
Hi there,

this patch by @peekjef72 (thanks!) will improve the datasource query interface, which is an experimental subsystem of grafana-client, aiming to provide a unified interface for querying data sources "behind" Grafana.

Dear @peekjef72, I am handing in your patch from GH-38 separately, to have something to compare against in the case something went wrong with the rebasing, and for your and future references.

I will continue here to add corresponding adjustments to the test suite, in order to integrate this patch.

With kind regards,
Andreas.
