### PR TITLE
Refine API wrapper for "Plugins" once more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+* Refine API wrapper for "Plugins" once more. Please note this adjustment changes
+  all the method names of the recently added "plugins" API wrappers, so it is
+  effectively a BREAKING CHANGE, if you used it already.
+
 
 ## 3.8.2 (2023-09-20)
 

--- a/test/elements/test_plugin.py
+++ b/test/elements/test_plugin.py
@@ -10,7 +10,7 @@ class PluginTestCase(unittest.TestCase):
         self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
 
     @requests_mock.Mocker()
-    def test_get_installed_plugins(self, m):
+    def test_list(self, m):
         m.get(
             "http://localhost/api/plugins?embedded=0",
             json=[
@@ -186,29 +186,29 @@ class PluginTestCase(unittest.TestCase):
                 },
             ],
         )
-        plugins = self.grafana.plugin.get_installed_plugins()
+        plugins = self.grafana.plugin.list()
         self.assertTrue(len(plugins), 6)
 
     @requests_mock.Mocker()
-    def test_install_plugin(self, m):
+    def test_install(self, m):
         m.post("http://localhost/api/plugins/alertlist/install", json={"message": "Plugin alertlist installed"})
-        response = self.grafana.plugin.install_plugin(pluginId="alertlist", version="1.3.12")
+        response = self.grafana.plugin.install(plugin_id="alertlist", version="1.3.12")
         self.assertEqual(response["message"], "Plugin alertlist installed")
 
     @requests_mock.Mocker()
-    def test_uninstall_plugin(self, m):
+    def test_uninstall(self, m):
         m.post("http://localhost/api/plugins/alertlist/uninstall", json={"message": "Plugin alertlist uninstalled"})
-        response = self.grafana.plugin.uninstall_plugin(pluginId="alertlist")
+        response = self.grafana.plugin.uninstall(plugin_id="alertlist")
         self.assertEqual(response["message"], "Plugin alertlist uninstalled")
 
     @requests_mock.Mocker()
-    def test_get_plugin_health(self, m):
+    def test_health(self, m):
         m.get("http://localhost/api/plugins/alertlist/health", json={"message": "Plugin alertlist healthy"})
-        response = self.grafana.plugin.health_check_plugin(pluginId="alertlist")
+        response = self.grafana.plugin.health(plugin_id="alertlist")
         self.assertEqual(response["message"], "Plugin alertlist healthy")
 
     @requests_mock.Mocker()
-    def test_get_plugin_metrics(self, m):
+    def test_metrics(self, m):
         m.get("http://localhost/api/plugins/grafana-timestream-datasource/metrics", json={"message": "Not found"})
-        response = self.grafana.plugin.get_plugin_metrics(pluginId="grafana-timestream-datasource")
+        response = self.grafana.plugin.metrics(plugin_id="grafana-timestream-datasource")
         self.assertEqual(response["message"], "Not found")


### PR DESCRIPTION
## About

After GH-110 and GH-114, this patch streamlines the API wrapper about "plugins" a bit more. 

## Details

1. The patch is needed to make https://github.com/panodata/grafana-wtf/pull/91 work.

2. While at it, it also adjusts/trims the method names a bit. I hope it will not cause too much harm, because the feature has only been released recently. I don't think we need to bump to 4.0.0 to properly signal that "breaking" change. I would just run a 3.9.0 release to ship it. Please let me know if you think differently.

/cc @bhks
