### PR TITLE
Plugins: Accept empty JSON response on plugin uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Plugins: Accept empty JSON response on plugin uninstall
+
 
 ## 3.9.0 (2023-09-21)
 

--- a/grafana_client/elements/plugin.py
+++ b/grafana_client/elements/plugin.py
@@ -55,7 +55,9 @@ class Plugin(Base):
         """
         try:
             path = "/plugins/%s/uninstall" % plugin_id
-            r = self.client.POST(path)
+            # Unfortunately, this endpoint may respond with an empty JSON,
+            # which needs compensation, because it does not decode well.
+            r = self.client.POST(path, accept_empty_json=True)
             return r
         except Exception as ex:
             if errors == "raise":


### PR DESCRIPTION
## About

Unfortunately, Grafana responds with empty JSON on some occasions, which causes all sorts of complications, and does not conform to the HTTP standard, see also GH-47 ff.

This happens here as well: Both the plugin installation and uninstallation endpoints may respond with an empty JSON, which needs compensation, because it does not decode well.

## References

- @bhks also was tripping into this flaw.
  > Thanks for handling this , I was not sure on how to handle the exceptions I was getting.
  > -- https://github.com/panodata/grafana-client/pull/115#discussion_r1332372062
- GH-47

/cc @mildwonkey, @zuchka
