### PR TITLE
Add support for Python 3.12, remove use of deprecated `distutils`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04"]
         python-version: [
-          '3.6', '3.11',
+          '3.6', '3.12',
           'pypy-3.6', 'pypy-3.10',
         ]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Add support for Python 3.12, remove use of deprecated `distutils`.
+  Thanks, @foreverhy.
+
 
 ## 3.9.1 (2023-09-21)
 

--- a/examples/datasource-health-check.py
+++ b/examples/datasource-health-check.py
@@ -6,10 +6,10 @@ Documentation: https://github.com/panodata/grafana-client/blob/main/examples/dat
 import json
 import logging
 import sys
-from distutils.version import LooseVersion
 from optparse import OptionParser
 
 import requests
+from verlib2 import Version
 
 from grafana_client import GrafanaApi
 from grafana_client.model import DatasourceHealthResponse
@@ -17,7 +17,7 @@ from grafana_client.util import setup_logging
 
 logger = logging.getLogger(__name__)
 
-VERSION_7 = LooseVersion("7")
+VERSION_7 = Version("7")
 
 
 def run(grafana: GrafanaApi):
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         logger.exception("Connecting to Grafana failed")
         raise SystemExit(1)
 
-    grafana_version = LooseVersion(grafana_client.version)
+    grafana_version = Version(grafana_client.version)
     if grafana_version < VERSION_7:
         raise NotImplementedError(f"Data source health check subsystem not ready for Grafana version {grafana_version}")
 

--- a/examples/datasource-health-probe.py
+++ b/examples/datasource-health-probe.py
@@ -6,10 +6,10 @@ Documentation: https://github.com/panodata/grafana-client/blob/main/examples/dat
 import json
 import logging
 import sys
-from distutils.version import LooseVersion
 from optparse import OptionParser
 
 import requests
+from verlib2 import Version
 
 from grafana_client import GrafanaApi
 from grafana_client.client import GrafanaClientError
@@ -20,9 +20,9 @@ from grafana_client.util import setup_logging
 logger = logging.getLogger(__name__)
 
 
-VERSION_7 = LooseVersion("7")
-VERSION_8 = LooseVersion("8")
-VERSION_9 = LooseVersion("9")
+VERSION_7 = Version("7")
+VERSION_8 = Version("8")
+VERSION_9 = Version("9")
 
 
 def ensure_datasource(grafana: GrafanaApi, datasource: DatasourceModel):
@@ -81,7 +81,7 @@ def prometheus_demo(grafana: GrafanaApi):
     return health_info
 
 
-def run(grafana: GrafanaApi, grafana_version: LooseVersion = None):
+def run(grafana: GrafanaApi, grafana_version: Version = None):
     # When called without options, invoke the Prometheus demo.
     if len(sys.argv) == 1:
         if grafana_version < VERSION_8:
@@ -132,7 +132,7 @@ if __name__ == "__main__":
         logger.exception("Connecting to Grafana failed")
         raise SystemExit(1)
 
-    grafana_version = LooseVersion(grafana_client.version)
+    grafana_version = Version(grafana_client.version)
     if grafana_version < VERSION_7:
         raise NotImplementedError(f"Data source health check subsystem not ready for Grafana version {grafana_version}")
 

--- a/grafana_client/__init__.py
+++ b/grafana_client/__init__.py
@@ -1,11 +1,8 @@
-import warnings
-
 try:
     from importlib.metadata import PackageNotFoundError, version
 except ModuleNotFoundError:  # pragma:nocover
     from importlib_metadata import PackageNotFoundError, version
 
-warnings.filterwarnings("ignore", category=Warning, message="distutils Version classes are deprecated")
 from .api import GrafanaApi  # noqa:E402,F401
 from .client import HeaderAuth, TokenAuth  # noqa:E402,F401
 

--- a/grafana_client/elements/dashboard.py
+++ b/grafana_client/elements/dashboard.py
@@ -1,6 +1,8 @@
-from distutils.version import LooseVersion
+from verlib2 import Version
 
 from .base import Base
+
+VERSION_8 = Version("8")
 
 
 class Dashboard(Base):
@@ -25,7 +27,7 @@ class Dashboard(Base):
         :param dashboard_name:
         :return:
         """
-        if self.api.version and LooseVersion(self.api.version) >= LooseVersion("8"):
+        if self.api.version and Version(self.api.version) >= VERSION_8:
             raise DeprecationWarning("Grafana 8 and higher does not support getting dashboards by slug")
         get_dashboard_path = "/dashboards/db/%s" % dashboard_name
         r = self.client.GET(get_dashboard_path)

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -2,11 +2,11 @@ import json
 import logging
 import time
 import warnings
-from distutils.version import LooseVersion
 from typing import Dict, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 from requests import ReadTimeout
+from verlib2 import Version
 
 from ..client import GrafanaBadInputError, GrafanaClientError, GrafanaServerError
 from ..knowledge import get_healthcheck_expression, query_factory
@@ -15,9 +15,9 @@ from .base import Base
 
 logger = logging.getLogger(__name__)
 
-VERSION_9 = LooseVersion("9")
-VERSION_8 = LooseVersion("8")
-VERSION_7 = LooseVersion("7")
+VERSION_9 = Version("9")
+VERSION_8 = Version("8")
+VERSION_7 = Version("7")
 VERBOSE = False
 
 
@@ -375,7 +375,7 @@ class Datasource(Base):
             request_kwargs = {}
             send_request = self.client.GET
 
-        elif datasource_type in ("prometheus", "loki") and LooseVersion(self.api.version) <= VERSION_7:
+        elif datasource_type in ("prometheus", "loki") and Version(self.api.version) <= VERSION_7:
             if (
                 "queries" in request["data"]
                 and len(request["data"]["queries"]) > 0
@@ -490,7 +490,7 @@ class Datasource(Base):
                     message = f"Invalid response. {reason}"
 
             elif datasource_type == "loki":
-                if self.api.version and VERSION_7 <= LooseVersion(self.api.version) < VERSION_8:
+                if self.api.version and VERSION_7 <= Version(self.api.version) < VERSION_8:
                     if "status" in response and response["status"] == "success":
                         message = "Success"
                         success = True
@@ -607,7 +607,7 @@ class Datasource(Base):
         start = time.time()
         raised = True
         noop = False
-        if self.api.version and LooseVersion(self.api.version) >= VERSION_9:
+        if self.api.version and Version(self.api.version) >= VERSION_9:
             try:
                 health_native = self.health(datasource_uid=datasource_uid)
                 logger.debug(f"Response from native data source health check: {health_native}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,4 @@ test-coverage = [
   {cmd="coverage report"},
 ]
 build = {cmd="python -m build"}
+check = ["lint", "test"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications
@@ -73,6 +74,7 @@ install_requires =
     requests>=2.23.0,<3
     dataclasses;python_version<='3.6'
     importlib-metadata;python_version<='3.7'
+    verlib2==0.1.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
## Description

Add support for Python 3.12, as suggested by @foreverhy.

## References

- GH-122
