### PR TITLE
Enable user

### DIFF
--- a/grafana_client/elements/admin.py
+++ b/grafana_client/elements/admin.py
@@ -75,3 +75,15 @@ class Admin(Base):
         change_user_permissions = "/admin/pause-all-alerts"
         r = self.client.POST(change_user_permissions, json={"paused": pause})
         return r
+
+    def set_user_enabled(self, user_id, enabled: bool):
+        """
+
+        :param user_id:
+        :param enabled:
+        :return:
+        """
+        action = 'enable' if enabled else 'disable'
+        set_user_enabled = '/admin/users/%s/%s' % (user_id, action)
+        r = self.client.POST(set_user_enabled)
+        return r

--- a/grafana_client/elements/admin.py
+++ b/grafana_client/elements/admin.py
@@ -83,7 +83,7 @@ class Admin(Base):
         :param enabled:
         :return:
         """
-        action = 'enable' if enabled else 'disable'
-        set_user_enabled = '/admin/users/%s/%s' % (user_id, action)
+        action = "enable" if enabled else "disable"
+        set_user_enabled = "/admin/users/%s/%s" % (user_id, action)
         r = self.client.POST(set_user_enabled)
         return r

--- a/test/elements/test_admin.py
+++ b/test/elements/test_admin.py
@@ -184,18 +184,12 @@ class AdminTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_enable_user(self, m):
-        m.post(
-            "http://localhost/api/admin/users/2/enable",
-            json={"message": "User enabled"}
-        )
+        m.post("http://localhost/api/admin/users/2/enable", json={"message": "User enabled"})
         user = self.grafana.admin.set_user_enabled(user_id=2, enabled=True)
         self.assertEqual(user["message"], "User enabled")
 
     @requests_mock.Mocker()
     def test_disable_user(self, m):
-        m.post(
-            "http://localhost/api/admin/users/2/disable",
-            json={"message": "User disabled"}
-        )
+        m.post("http://localhost/api/admin/users/2/disable", json={"message": "User disabled"})
         user = self.grafana.admin.set_user_enabled(user_id=2, enabled=False)
         self.assertEqual(user["message"], "User disabled")

--- a/test/elements/test_admin.py
+++ b/test/elements/test_admin.py
@@ -181,3 +181,21 @@ class AdminTestCase(unittest.TestCase):
         )
         pause = self.grafana.admin.pause_all_alerts(pause="True")
         self.assertEqual(pause["message"], "alert paused")
+
+    @requests_mock.Mocker()
+    def test_enable_user(self, m):
+        m.post(
+            "http://localhost/api/admin/users/2/enable",
+            json={"message": "User enabled"}
+        )
+        user = self.grafana.admin.set_user_enabled(user_id=2, enabled=True)
+        self.assertEqual(user["message"], "User enabled")
+
+    @requests_mock.Mocker()
+    def test_disable_user(self, m):
+        m.post(
+            "http://localhost/api/admin/users/2/disable",
+            json={"message": "User disabled"}
+        )
+        user = self.grafana.admin.set_user_enabled(user_id=2, enabled=False)
+        self.assertEqual(user["message"], "User disabled")


### PR DESCRIPTION
## Description
Add method to enable/disable a given user.
While not in Grafana docs, methods for enabling and disabling can be found in the [source](https://github.com/grafana/grafana/blob/b1618005515acfcec0d93b4def0915639fae1553/pkg/api/admin_users.go#L294) [code](https://github.com/grafana/grafana/blob/b1618005515acfcec0d93b4def0915639fae1553/pkg/api/admin_users.go#L337)


## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [ ] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
