### PR TITLE
Fix Query with InfluxQL

### DIFF
--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -169,6 +169,8 @@ def query_factory(datasource, model: Optional[dict] = None, expression: Optional
             # "datasourceId": datasource.get("id"),
         }
         if dialect == "InfluxQL":
+            if model.get("database"):
+                query["db"] = model["database"]
             query.update(
                 {
                     "q": expression,


### PR DESCRIPTION
Fix: {'results': [{'error': 'database name required', 'statement_id': 0}]} when using Influxdb with InfluxQL. 

Add Field "db" to query:
{'data': {'refId': 'test', 'db': 'icinga2', 'q': 'SELECT ....'}}

## Description
When using grafana-client with influxdb/influxql query is missing db field.  

## Checklist

- [ ] The patch has appropriate test coverage
- [ ] The patch follows the style guidelines of this project
- [ ] The patch has appropriate comments, particularly in hard-to-understand areas
- [ ] The documentation was updated corresponding to the patch
- [ ] I have performed a self-review of this patch
