### PR TITLE
Address Grafana 10.2.3: breaking changes

### DIFF
--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -188,7 +188,7 @@ class Datasource(Base):
         :return:
         """
         if Version(self.api.version) > VERSION_10_2_2:
-            raise NotImplementedError("This binding is no longer available")
+            raise NotImplementedError("Deprecated since Grafana 10.2.3")
 
         get_datasource_path = "/datasources/%s/enable-permissions" % datasource_id
         r = self.client.POST(get_datasource_path)
@@ -202,7 +202,7 @@ class Datasource(Base):
         :return:
         """
         if Version(self.api.version) > VERSION_10_2_2:
-            raise NotImplementedError("This binding is no longer available")
+            raise NotImplementedError("Deprecated since Grafana 10.2.3")
 
         get_datasource_path = "/datasources/%s/disable-permissions" % datasource_id
         r = self.client.POST(get_datasource_path)
@@ -216,7 +216,7 @@ class Datasource(Base):
         :return:
         """
         if Version(self.api.version) > VERSION_10_2_2:
-            raise NotImplementedError("This binding is no longer available, replaced by get_rbac_datasources()")
+            raise NotImplementedError("Deprecated since Grafana 10.2.3, please use get_rbac_datasources()")
 
         get_datasource_path = "/datasources/%s/permissions" % datasource_id
         r = self.client.GET(get_datasource_path)
@@ -231,7 +231,7 @@ class Datasource(Base):
         :return:
         """
         if Version(self.api.version) > VERSION_10_2_2:
-            raise NotImplementedError("This binding is no longer available, replaced by set_rbac_datasources_*()")
+            raise NotImplementedError("Deprecated since Grafana 10.2.3, please use set_rbac_datasources_*()")
 
         get_datasource_path = "/datasources/%s/permissions" % datasource_id
         r = self.client.POST(get_datasource_path, json=permissions)
@@ -246,7 +246,7 @@ class Datasource(Base):
         :return:
         """
         if Version(self.api.version) > VERSION_10_2_2:
-            raise NotImplementedError("This binding is no longer available, replaced by set_rbac_datasources_*()")
+            raise NotImplementedError("Deprecated since Grafana 10.2.3, please use set_rbac_datasources_*()")
 
         get_datasource_path = "/datasources/%s/permissions/%s" % (datasource_id, permission_id)
         r = self.client.DELETE(get_datasource_path)

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -15,6 +15,7 @@ from .base import Base
 
 logger = logging.getLogger(__name__)
 
+VERSION_10_2_2 = Version("10.2.2")
 VERSION_9 = Version("9")
 VERSION_8 = Version("8")
 VERSION_7 = Version("7")
@@ -186,6 +187,9 @@ class Datasource(Base):
         :param datasource_id:
         :return:
         """
+        if Version(self.api.version) > VERSION_10_2_2:
+            raise NotImplementedError("This binding is no longer available")
+
         get_datasource_path = "/datasources/%s/enable-permissions" % datasource_id
         r = self.client.POST(get_datasource_path)
         return r
@@ -197,6 +201,9 @@ class Datasource(Base):
         :param datasource_id:
         :return:
         """
+        if Version(self.api.version) > VERSION_10_2_2:
+            raise NotImplementedError("This binding is no longer available")
+
         get_datasource_path = "/datasources/%s/disable-permissions" % datasource_id
         r = self.client.POST(get_datasource_path)
         return r
@@ -208,6 +215,9 @@ class Datasource(Base):
         :param datasource_id:
         :return:
         """
+        if Version(self.api.version) > VERSION_10_2_2:
+            raise NotImplementedError("This binding is no longer available, replaced by get_rbac_datasources()")
+
         get_datasource_path = "/datasources/%s/permissions" % datasource_id
         r = self.client.GET(get_datasource_path)
         return r
@@ -220,6 +230,9 @@ class Datasource(Base):
         :param permissions:
         :return:
         """
+        if Version(self.api.version) > VERSION_10_2_2:
+            raise NotImplementedError("This binding is no longer available, replaced by set_rbac_datasources_*()")
+
         get_datasource_path = "/datasources/%s/permissions" % datasource_id
         r = self.client.POST(get_datasource_path, json=permissions)
         return r
@@ -232,6 +245,9 @@ class Datasource(Base):
         :param permission_id:
         :return:
         """
+        if Version(self.api.version) > VERSION_10_2_2:
+            raise NotImplementedError("This binding is no longer available, replaced by set_rbac_datasources_*()")
+
         get_datasource_path = "/datasources/%s/permissions/%s" % (datasource_id, permission_id)
         r = self.client.DELETE(get_datasource_path)
         return r

--- a/grafana_client/elements/rbac.py
+++ b/grafana_client/elements/rbac.py
@@ -51,3 +51,58 @@ class Rbac(Base):
         role_team_path = "/access-control/teams/%s/roles/%s" % (team_id, role_uid)
         r = self.client.DELETE(role_team_path)
         return r
+
+    def get_rbac_datasources(self, datasource_uid):
+        """
+        Gets all existing permissions for the data source with the given uid
+
+        The Rbac is only available in Grafana Enterprise.
+        This API works only with grafana version > 10.2.3.
+
+        :param datasource_uid:
+        :return:
+        """
+        datasource_path = "/access-control/datasources/%s" % datasource_uid
+        r = self.client.GET(datasource_path)
+        return r
+
+    def set_rbac_datasources_teams(self, datasource_uid, team_id, permission):
+        """
+        Sets team permission for the data source with the given uid.
+
+        the values allowed for the permission argument are :
+        Query, Edit, or Admin.
+        To remove a permission, set the permission argument to an empty string.
+        The Rbac is only available in Grafana Enterprise.
+        This API works only with grafana version > 10.2.3.
+
+        :param datasource_uid:
+        :param team_id:
+        :param permission:
+        :return:
+        """
+        datasource_path = "/access-control/datasources/%s/teams/%s" % (datasource_uid, team_id)
+        r = self.client.POST(datasource_path, json={"permission": permission})
+        return r
+
+    def set_rbac_datasources_builtin_roles(self, datasource_uid, builtin_role, permission):
+        """
+        Sets permission for the data source with the given uid to all users who
+        have the specified basic role.
+
+        the values allowed for the builtin_role argument are :
+        Admin, Editor or Viewer
+        the values allowed for the permission argument are :
+        Query, Edit, or Admin.
+        To remove a permission, set the permission argument to an empty string.
+        The Rbac is only available in Grafana Enterprise.
+        This API works only with grafana version > 10.2.3.
+
+        :param datasource_uid:
+        :param builtin_role:
+        :param permission:
+        :return:
+        """
+        datasource_path = "/access-control/datasources/%s/builtInRoles/%s" % (datasource_uid, builtin_role)
+        r = self.client.POST(datasource_path, json={"permission": permission})
+        return r

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -135,6 +135,21 @@ class DatasourceTestCase(unittest.TestCase):
         self.assertEqual(result, {"message": "Datasource permissions enabled"})
 
     @requests_mock.Mocker()
+    def test_enable_datasource_permissions_grafana1023(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+        )
+
+        with patch(
+            "grafana_client.api.Datasource.enable_datasource_permissions",
+            side_effect=NotImplementedError("This binding is no longer available"),
+        ):
+            with self.assertRaises(NotImplementedError) as context:
+                self.grafana.datasource.enable_datasource_permissions(42)
+            self.assertEqual(str(context.exception), "This binding is no longer available")
+
+    @requests_mock.Mocker()
     def test_disable_datasource_permissions(self, m):
         m.get(
             "http://localhost/api/health",
@@ -148,6 +163,21 @@ class DatasourceTestCase(unittest.TestCase):
 
         result = self.grafana.datasource.disable_datasource_permissions(42)
         self.assertEqual(result, {"message": "Datasource permissions disabled"})
+
+    @requests_mock.Mocker()
+    def test_disable_datasource_permissions_grafana1023(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+        )
+
+        with patch(
+            "grafana_client.api.Datasource.disable_datasource_permissions",
+            side_effect=NotImplementedError("This binding is no longer available"),
+        ):
+            with self.assertRaises(NotImplementedError) as context:
+                self.grafana.datasource.disable_datasource_permissions(42)
+            self.assertEqual(str(context.exception), "This binding is no longer available")
 
     @requests_mock.Mocker()
     def test_get_datasource_permissions(self, m):
@@ -165,6 +195,21 @@ class DatasourceTestCase(unittest.TestCase):
         self.assertEqual(result["datasourceId"], 42)
 
     @requests_mock.Mocker()
+    def test_get_datasource_permissions_grafana1023(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+        )
+
+        with patch(
+            "grafana_client.api.Datasource.get_datasource_permissions",
+            side_effect=NotImplementedError("This binding is no longer available"),
+        ):
+            with self.assertRaises(NotImplementedError) as context:
+                self.grafana.datasource.get_datasource_permissions(42)
+            self.assertEqual(str(context.exception), "This binding is no longer available")
+
+    @requests_mock.Mocker()
     def test_add_datasource_permissions(self, m):
         m.get(
             "http://localhost/api/health",
@@ -177,6 +222,21 @@ class DatasourceTestCase(unittest.TestCase):
         self.assertEqual(result, {"message": "Datasource permission added"})
 
     @requests_mock.Mocker()
+    def test_add_datasource_permissions_grafana1023(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+        )
+
+        with patch(
+            "grafana_client.api.Datasource.add_datasource_permissions",
+            side_effect=NotImplementedError("This binding is no longer available"),
+        ):
+            with self.assertRaises(NotImplementedError) as context:
+                self.grafana.datasource.add_datasource_permissions(42, {"userId": 1, "permission": 1})
+            self.assertEqual(str(context.exception), "This binding is no longer available")
+
+    @requests_mock.Mocker()
     def test_remove_datasource_permissions(self, m):
         m.get(
             "http://localhost/api/health",
@@ -187,6 +247,21 @@ class DatasourceTestCase(unittest.TestCase):
 
         result = self.grafana.datasource.remove_datasource_permissions(42, 1)
         self.assertEqual(result, {"message": "Datasource permission removed"})
+
+    @requests_mock.Mocker()
+    def test_remove_datasource_permissions_grafana1023(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+        )
+
+        with patch(
+            "grafana_client.api.Datasource.remove_datasource_permissions",
+            side_effect=NotImplementedError("This binding is no longer available"),
+        ):
+            with self.assertRaises(NotImplementedError) as context:
+                self.grafana.datasource.remove_datasource_permissions(42, 1)
+            self.assertEqual(str(context.exception), "This binding is no longer available")
 
     @requests_mock.Mocker()
     def test_find_datasource(self, m):

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -122,6 +122,11 @@ class DatasourceTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_enable_datasource_permissions(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+        )
+
         m.post(
             "http://localhost/api/datasources/42/enable-permissions", json={"message": "Datasource permissions enabled"}
         )
@@ -131,6 +136,11 @@ class DatasourceTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_disable_datasource_permissions(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+        )
+
         m.post(
             "http://localhost/api/datasources/42/disable-permissions",
             json={"message": "Datasource permissions disabled"},
@@ -142,6 +152,11 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_datasource_permissions(self, m):
         m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+        )
+
+        m.get(
             "http://localhost/api/datasources/42/permissions",
             json=PERMISSION_DATASOURCE,
         )
@@ -151,6 +166,11 @@ class DatasourceTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_add_datasource_permissions(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+        )
+
         m.post("http://localhost/api/datasources/42/permissions", json={"message": "Datasource permission added"})
 
         result = self.grafana.datasource.add_datasource_permissions(42, {"userId": 1, "permission": 1})
@@ -158,6 +178,11 @@ class DatasourceTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_remove_datasource_permissions(self, m):
+        m.get(
+            "http://localhost/api/health",
+            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+        )
+
         m.delete("http://localhost/api/datasources/42/permissions/1", json={"message": "Datasource permission removed"})
 
         result = self.grafana.datasource.remove_datasource_permissions(42, 1)

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -143,11 +143,11 @@ class DatasourceTestCase(unittest.TestCase):
 
         with patch(
             "grafana_client.api.Datasource.enable_datasource_permissions",
-            side_effect=NotImplementedError("This binding is no longer available"),
+            side_effect=NotImplementedError("Deprecated since Grafana 10.2.3"),
         ):
             with self.assertRaises(NotImplementedError) as context:
                 self.grafana.datasource.enable_datasource_permissions(42)
-            self.assertEqual(str(context.exception), "This binding is no longer available")
+            self.assertEqual(str(context.exception), "Deprecated since Grafana 10.2.3")
 
     @requests_mock.Mocker()
     def test_disable_datasource_permissions(self, m):
@@ -173,11 +173,11 @@ class DatasourceTestCase(unittest.TestCase):
 
         with patch(
             "grafana_client.api.Datasource.disable_datasource_permissions",
-            side_effect=NotImplementedError("This binding is no longer available"),
+            side_effect=NotImplementedError("Deprecated since Grafana 10.2.3"),
         ):
             with self.assertRaises(NotImplementedError) as context:
                 self.grafana.datasource.disable_datasource_permissions(42)
-            self.assertEqual(str(context.exception), "This binding is no longer available")
+            self.assertEqual(str(context.exception), "Deprecated since Grafana 10.2.3")
 
     @requests_mock.Mocker()
     def test_get_datasource_permissions(self, m):
@@ -203,11 +203,11 @@ class DatasourceTestCase(unittest.TestCase):
 
         with patch(
             "grafana_client.api.Datasource.get_datasource_permissions",
-            side_effect=NotImplementedError("This binding is no longer available"),
+            side_effect=NotImplementedError("Deprecated since Grafana 10.2.3"),
         ):
             with self.assertRaises(NotImplementedError) as context:
                 self.grafana.datasource.get_datasource_permissions(42)
-            self.assertEqual(str(context.exception), "This binding is no longer available")
+            self.assertEqual(str(context.exception), "Deprecated since Grafana 10.2.3")
 
     @requests_mock.Mocker()
     def test_add_datasource_permissions(self, m):
@@ -230,11 +230,11 @@ class DatasourceTestCase(unittest.TestCase):
 
         with patch(
             "grafana_client.api.Datasource.add_datasource_permissions",
-            side_effect=NotImplementedError("This binding is no longer available"),
+            side_effect=NotImplementedError("Deprecated since Grafana 10.2.3"),
         ):
             with self.assertRaises(NotImplementedError) as context:
                 self.grafana.datasource.add_datasource_permissions(42, {"userId": 1, "permission": 1})
-            self.assertEqual(str(context.exception), "This binding is no longer available")
+            self.assertEqual(str(context.exception), "Deprecated since Grafana 10.2.3")
 
     @requests_mock.Mocker()
     def test_remove_datasource_permissions(self, m):
@@ -257,11 +257,11 @@ class DatasourceTestCase(unittest.TestCase):
 
         with patch(
             "grafana_client.api.Datasource.remove_datasource_permissions",
-            side_effect=NotImplementedError("This binding is no longer available"),
+            side_effect=NotImplementedError("Deprecated since Grafana 10.2.3"),
         ):
             with self.assertRaises(NotImplementedError) as context:
                 self.grafana.datasource.remove_datasource_permissions(42, 1)
-            self.assertEqual(str(context.exception), "This binding is no longer available")
+            self.assertEqual(str(context.exception), "Deprecated since Grafana 10.2.3")
 
     @requests_mock.Mocker()
     def test_find_datasource(self, m):

--- a/test/elements/test_rbac_fixtures.py
+++ b/test/elements/test_rbac_fixtures.py
@@ -1,0 +1,55 @@
+RBAC_ROLES_ALL = [
+    {
+        "version": 5,
+        "uid": "vi9mlLjGz",
+        "name": "fixed:datasources.permissions:writer",
+        "description": "Create, read or delete data source permissions.",
+        "global": True,
+        "updated": "2021-05-13T22:41:49+02:00",
+        "created": "2021-05-13T16:24:26+02:00",
+    }
+]
+
+PERMISSION_RBAC_DATASOURCE = [
+    {
+        "id": 1,
+        "roleName": "fixed:datasources:reader",
+        "isManaged": False,
+        "isInherited": False,
+        "isServiceAccount": False,
+        "userId": 1,
+        "userLogin": "admin_user",
+        "userAvatarUrl": "/avatar/admin_user",
+        "actions": [
+            "datasources:read",
+            "datasources:query",
+            "datasources:read",
+            "datasources:query",
+            "datasources:write",
+            "datasources:delete",
+        ],
+        "permission": "Edit",
+    },
+    {
+        "id": 2,
+        "roleName": "managed:teams:1:permissions",
+        "isManaged": True,
+        "isInherited": False,
+        "isServiceAccount": False,
+        "team": "A team",
+        "teamId": 1,
+        "teamAvatarUrl": "/avatar/523d70c8551046f441727d690431858c",
+        "actions": ["datasources:read", "datasources:query"],
+        "permission": "Query",
+    },
+    {
+        "id": 3,
+        "roleName": "basic:admin",
+        "isManaged": False,
+        "isInherited": False,
+        "isServiceAccount": False,
+        "builtInRole": "Admin",
+        "actions": ["datasources:query", "datasources:read", "datasources:write", "datasources:delete"],
+        "permission": "Edit",
+    },
+]


### PR DESCRIPTION
Grafana-client is no longer compatible with the data source permissions APIs of grafana Enterprise 10.2.3. This commit adds the new APIs :

- GET  /api/access-control/datasources/:uid for listing data source permissions
- POST /api/access-control/datasources/:uid/teams/:id for adding or removing data source permissions
- POST /api/access-control/datasources/:uid/buildInRoles/:id for adding or removing data source permissions

## Description
https://github.com/panodata/grafana-client/issues/147

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
