### PR TITLE
[BUG FIX] API DELETE /api/teams/:teamId/groups?groupId=external-group-id

### DIFF
--- a/grafana_client/elements/team.py
+++ b/grafana_client/elements/team.py
@@ -215,6 +215,6 @@ class Teams(Base):
         :param group_id:
         :return:
         """
-        team_group_path = "/teams/%s/groups/%s" % (team_id, group_id)
+        team_group_path = "/teams/%s/groups?groupId=%s" % (team_id, group_id)
         r = self.client.DELETE(team_group_path)
         return r

--- a/test/elements/test_team.py
+++ b/test/elements/test_team.py
@@ -327,8 +327,8 @@ class TeamsTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove_team_external_group(self, m):
         m.delete(
-            "http://localhost/api/teams/42/groups/1",
+            "http://localhost/api/teams/42/groups?groupId=a_external_group",
             json={"message": "Team group removed"},
         )
-        r = self.grafana.teams.remove_team_external_group("42", "1")
+        r = self.grafana.teams.remove_team_external_group("42", "a_external_group")
         self.assertEqual(r["message"], "Team group removed")


### PR DESCRIPTION
## Description
Fix incorrect API call parameter : It returned always 404.

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
