### PR TITLE
Improve support for folders, by adding `parent_uid` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   uses `GrafanaTimeoutError` instead. Other than this, [Niquests] is a drop-
   in replacement for [Requests] and therefore is largely compatible.
 * Remove Python 3.6 support. Thanks, @Ousret.
+* Improve support for folders, by adding ``parent_uid`` option to relevant
+  endpoints, and by adding missing ``move_folder``. Thanks, @grafuls.
 
 [Niquests]: https://niquests.readthedocs.io/
 [Riquests]: https://requests.readthedocs.io/

--- a/grafana_client/elements/_async/folder.py
+++ b/grafana_client/elements/_async/folder.py
@@ -6,13 +6,16 @@ class Folder(Base):
         super(Folder, self).__init__(client)
         self.client = client
 
-    async def get_all_folders(self):
+    async def get_all_folders(self, parent_uid=None):
         """
 
         :return:
         """
         path = "/folders"
-        return await self.client.GET(path)
+        data = {}
+        if parent_uid:
+            data["parentUid"] = parent_uid
+        return await self.client.GET(path, data=data)
 
     async def get_folder(self, uid):
         """
@@ -23,17 +26,33 @@ class Folder(Base):
         path = "/folders/%s" % uid
         return await self.client.GET(path)
 
-    async def create_folder(self, title, uid=None):
+    async def create_folder(self, title, uid=None, parent_uid=None):
         """
 
         :param title:
         :param uid:
+        :param parent_uid:
         :return:
         """
         json_data = dict(title=title)
         if uid is not None:
             json_data["uid"] = uid
+        if parent_uid is not None:
+            json_data["parentUid"] = parent_uid
         return await self.client.POST("/folders", json=json_data)
+
+    async def move_folder(self, uid, parent_uid):
+        """
+        Move a folder beneath another parent folder.
+
+        This is relevant only if nested folders are enabled.
+
+        :param uid:
+        :param parent_uid:
+        :return:
+        """
+        path = "/folders/%s/move" % uid
+        return await self.client.POST(path, json={"parentUid": parent_uid})
 
     async def update_folder(self, uid, title=None, version=None, overwrite=False, new_uid=None):
         """

--- a/grafana_client/elements/folder.py
+++ b/grafana_client/elements/folder.py
@@ -6,13 +6,16 @@ class Folder(Base):
         super(Folder, self).__init__(client)
         self.client = client
 
-    def get_all_folders(self):
+    def get_all_folders(self, parent_uid=None):
         """
 
         :return:
         """
         path = "/folders"
-        return self.client.GET(path)
+        data = {}
+        if parent_uid:
+            data["parentUid"] = parent_uid
+        return self.client.GET(path, data=data)
 
     def get_folder(self, uid):
         """
@@ -23,17 +26,33 @@ class Folder(Base):
         path = "/folders/%s" % uid
         return self.client.GET(path)
 
-    def create_folder(self, title, uid=None):
+    def create_folder(self, title, uid=None, parent_uid=None):
         """
 
         :param title:
         :param uid:
+        :param parent_uid:
         :return:
         """
         json_data = dict(title=title)
         if uid is not None:
             json_data["uid"] = uid
+        if parent_uid is not None:
+            json_data["parentUid"] = parent_uid
         return self.client.POST("/folders", json=json_data)
+
+    def move_folder(self, uid, parent_uid):
+        """
+        Move a folder beneath another parent folder.
+
+        This is relevant only if nested folders are enabled.
+
+        :param uid:
+        :param parent_uid:
+        :return:
+        """
+        path = "/folders/%s/move" % uid
+        return self.client.POST(path, json={"parentUid": parent_uid})
 
     def update_folder(self, uid, title=None, version=None, overwrite=False, new_uid=None):
         """

--- a/test/elements/test_folder.py
+++ b/test/elements/test_folder.py
@@ -32,7 +32,7 @@ class FolderTestCase(unittest.TestCase):
                 }
             ],
         )
-        folders = self.grafana.folder.get_all_folders()
+        folders = self.grafana.folder.get_all_folders(parent_uid="gFtOEwFlbb")
         self.assertEqual(folders[0]["id"], 1)
         self.assertEqual(len(folders), 1)
 
@@ -66,6 +66,7 @@ class FolderTestCase(unittest.TestCase):
             json={
                 "id": 1,
                 "uid": "nErXDvCkzz",
+                "parentUid": "gFtOEwFlbb",
                 "title": "Departmenet ABC",
                 "url": "/dashboards/f/nErXDvCkzz/department-abc",
                 "hasAcl": "false",
@@ -79,8 +80,9 @@ class FolderTestCase(unittest.TestCase):
                 "version": 1,
             },
         )
-        folder = self.grafana.folder.create_folder(title="Departmenet ABC", uid="nErXDvCkzz")
+        folder = self.grafana.folder.create_folder(title="Departmenet ABC", uid="nErXDvCkzz", parent_uid="gFtOEwFlbb")
         self.assertEqual(folder["uid"], "nErXDvCkzz")
+        self.assertEqual(folder["parentUid"], "gFtOEwFlbb")
 
     @requests_mock.Mocker()
     def test_create_folder_empty_uid(self, m):
@@ -91,6 +93,31 @@ class FolderTestCase(unittest.TestCase):
         )
         with self.assertRaises(GrafanaBadInputError):
             self.grafana.folder.create_folder(title="Departmenet ABC")
+
+    @requests_mock.Mocker()
+    def test_move_folder(self, m):
+        m.post(
+            "http://localhost/api/folders/nErXDvCkzz/move",
+            json={
+                "id": 1,
+                "uid": "nErXDvCkzz",
+                "parentUid": "gFtOEwFlbb",
+                "title": "Departmenet ABC",
+                "url": "/dashboards/f/nErXDvCkzz/department-abc",
+                "hasAcl": "false",
+                "canSave": "false",
+                "canEdit": "false",
+                "canAdmin": "false",
+                "createdBy": "admin",
+                "created": "2018-01-31T17:43:12+01:00",
+                "updatedBy": "admin",
+                "updated": "2018-01-31T17:43:12+01:00",
+                "version": 1,
+            },
+        )
+        folder = self.grafana.folder.move_folder(uid="nErXDvCkzz", parent_uid="gFtOEwFlbb")
+        self.assertEqual(folder["uid"], "nErXDvCkzz")
+        self.assertEqual(folder["parentUid"], "gFtOEwFlbb")
 
     @requests_mock.Mocker()
     def test_update_folder(self, m):


### PR DESCRIPTION
## About

This patch intends to improve the situation about missing `parantUid` parameters on a few endpoints of the ["folder"](https://grafana.com/docs/grafana/latest/developers/http_api/folder/) family, as reported by @grafuls on behalf of  GH-160. Thanks!

Along the lines, the [`move_folder`](https://grafana.com/docs/grafana/latest/developers/http_api/folder/#move-folder) command also has been added, as it was missing completely.
