### PR TITLE
Service Accounts: Unlock endpoint to update service account by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Remove Python 3.6 support. Thanks, @Ousret.
 * Improve support for folders, by adding ``parent_uid`` option to relevant
   endpoints, and by adding missing ``move_folder``. Thanks, @grafuls.
+* Service Accounts: Unlock endpoint to update service account by id.
+  Thanks, @einar-lanfranco.
 
 [Niquests]: https://niquests.readthedocs.io/
 [Riquests]: https://requests.readthedocs.io/

--- a/grafana_client/elements/_async/service_account.py
+++ b/grafana_client/elements/_async/service_account.py
@@ -35,12 +35,24 @@ class ServiceAccount(Base):
         create_service_account_path = "/serviceaccounts/"
         return await self.client.POST(create_service_account_path, json=service_account)
 
+    async def update(self, service_account_id, service_account):
+        """
+        Update service account by id.
+        https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#update-service-account
+
+        :param service_account_id:
+        :param service_account: {"name": "string", "role": "string"}
+        :return:
+        """
+        path = "/serviceaccounts/%s" % service_account_id
+        return await self.client.PATCH(path, json=service_account)
+
     async def delete(self, service_account_id):
         """
         Delete service account.
         https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#delete-service-account
 
-        :param service_account:
+        :param service_account_id:
         :return:
         """
 

--- a/grafana_client/elements/service_account.py
+++ b/grafana_client/elements/service_account.py
@@ -35,12 +35,24 @@ class ServiceAccount(Base):
         create_service_account_path = "/serviceaccounts/"
         return self.client.POST(create_service_account_path, json=service_account)
 
+    def update(self, service_account_id, service_account):
+        """
+        Update service account by id.
+        https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#update-service-account
+
+        :param service_account_id:
+        :param service_account: {"name": "string", "role": "string"}
+        :return:
+        """
+        path = "/serviceaccounts/%s" % service_account_id
+        return self.client.PATCH(path, json=service_account)
+
     def delete(self, service_account_id):
         """
         Delete service account.
         https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#delete-service-account
 
-        :param service_account:
+        :param service_account_id:
         :return:
         """
 

--- a/test/elements/test_service_account.py
+++ b/test/elements/test_service_account.py
@@ -67,6 +67,15 @@ class ServiceAccountsTestCase(unittest.TestCase):
         self.assertEqual(user["message"], "Service account created")
 
     @requests_mock.Mocker()
+    def test_update(self, m):
+        m.patch(
+            "http://localhost/api/serviceaccounts/42",
+            json={"message": "Service account updated"},
+        )
+        user = self.grafana.serviceaccount.update(42, {"name": "foo", "role": "Admin"})
+        self.assertEqual(user["message"], "Service account updated")
+
+    @requests_mock.Mocker()
     def test_delete(self, m):
         m.delete(
             "http://localhost/api/serviceaccounts/42",


### PR DESCRIPTION
## About

Unlock missing endpoint to update service accounts.
- https://github.com/panodata/grafana-client/issues/137#issuecomment-1881964798
