### PR TITLE
Packaging: Do not mark package as "universal wheel" py2, py3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Packaging: Do not mark package as "universal wheel" py2, py3.
+  Thanks, @Ousret.
+
 
 ## 4.0.0 (2024-03-29)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,9 +93,6 @@ develop =
 where = .
 exclude = test
 
-[bdist_wheel]
-universal = true
-
 [tool.setuptools_scm]
 local_scheme = no-local-version
 version_scheme = python-simplified-semver


### PR DESCRIPTION
## About

@Ousret advised:

> Side note, grafana client is marked as "universal wheel" py2, py3 when it should not.
>
> This section should be removed in the setup.cfg
>
> ```ini
> [bdist_wheel]
> universal = true
> ```

Thanks!

## References
- https://github.com/panodata/grafana-wtf/issues/126#issuecomment-2027373123