### PR TITLE
Dashboard search: Improve handling of `tag` keywords argument 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## unreleased
+- Dashboard search: Improved handling of `tag` keywords argument to also
+  process lists, when searching for multiple tags.
 
 ## 5.1.0 (2026-04-22)
 - Fixed health probe for InfluxDB v1.

--- a/grafana_client/elements/_async/search.py
+++ b/grafana_client/elements/_async/search.py
@@ -1,4 +1,4 @@
-from grafana_client.util import as_bool, format_param_value
+from grafana_client.util import as_bool, format_param_value, to_list
 
 from ..base import Base
 
@@ -42,7 +42,7 @@ class Search(Base):
             params["query"] = query
 
         if tag is not None:
-            params["tag"] = format_param_value(tag)
+            params["tag"] = to_list(tag)
 
         if type_ is not None:
             params["type"] = type_

--- a/grafana_client/elements/search.py
+++ b/grafana_client/elements/search.py
@@ -1,4 +1,4 @@
-from grafana_client.util import as_bool, format_param_value
+from grafana_client.util import as_bool, format_param_value, to_list
 
 from .base import Base
 
@@ -42,7 +42,7 @@ class Search(Base):
             params["query"] = query
 
         if tag is not None:
-            params["tag"] = format_param_value(tag)
+            params["tag"] = to_list(tag)
 
         if type_ is not None:
             params["type"] = type_

--- a/grafana_client/util.py
+++ b/grafana_client/util.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import typing as t
 
 
 def setup_logging(level=logging.INFO):
@@ -46,3 +47,19 @@ def format_param_value(maybe_list):
         return ",".join([str(x) for x in maybe_list])
     else:
         return maybe_list
+
+
+def to_list(x: t.Any, default: t.Optional[t.List[t.Any]] = None) -> t.List[t.Any]:
+    """Cast scalar to list."""
+    if default is None:
+        default = []
+    if not isinstance(default, list):
+        raise ValueError("Default value is not a list")
+    if x is None:
+        return default
+    if isinstance(x, str) or not isinstance(x, t.Iterable):
+        return [x]
+
+    if isinstance(x, list):
+        return x
+    return list(x)

--- a/test/elements/test_search.py
+++ b/test/elements/test_search.py
@@ -71,9 +71,25 @@ class SearchTestCase(unittest.TestCase):
         else:
             self.assertEqual(2, len(result), "Wrong number of dashboards")
 
-    def test_search_dashboards_by_tag(self):
+    def test_search_dashboards_by_tag_single(self):
         result = self.grafana.search.search_dashboards(
-            tag="bazqux",
+            tag=["foobar"],
+        )
+        self.assertEqual(1, len(result), "Wrong number of dashboards")
+        self.assertEqual(self.dashboard_uid, result[0]["uid"])
+
+    def test_search_dashboards_by_tag_multiple(self):
+        result = self.grafana.search.search_dashboards(
+            tag=["foobar", "bazqux"],
+        )
+        self.assertEqual(1, len(result), "Wrong number of dashboards")
+        self.assertEqual(self.dashboard_uid, result[0]["uid"])
+
+    def test_search_dashboards_by_tag_wildcard(self):
+        if self.grafana.get_version() < Version("12.4"):
+            pytest.skip("Searching dashboards with wildcards in tags only supported with Grafana 12.4 and higher")
+        result = self.grafana.search.search_dashboards(
+            tag=["foo*", "baz*"],
         )
         self.assertEqual(1, len(result), "Wrong number of dashboards")
         self.assertEqual(self.dashboard_uid, result[0]["uid"])

--- a/test/elements/test_search.py
+++ b/test/elements/test_search.py
@@ -46,8 +46,8 @@ class SearchTestCase(unittest.TestCase):
         self.assertEqual(self.dashboard_uid, result[0]["uid"])
 
     def test_search_dashboards_by_query_tags(self):
-        if self.grafana.get_version() < Version("12.4"):
-            pytest.skip("Dashboard tags are only indexed with Grafana 12.4 and higher.")
+        if not Version("12.4") <= self.grafana.get_version() < Version("13"):
+            pytest.skip("Dashboard tags are only fulltext-indexed with Grafana 12.4")
         result = self.grafana.search.search_dashboards(
             query="foobar",
         )


### PR DESCRIPTION
A little patch that includes a minor improvement and another little clarification.